### PR TITLE
Policy engine: TypeScript (Deno + Hono) port

### DIFF
--- a/src/policy_engine/bundled-actions-net-only/actions/checkout/action.yml
+++ b/src/policy_engine/bundled-actions-net-only/actions/checkout/action.yml
@@ -1,0 +1,14 @@
+name: Tangled Checkout
+description: >
+  Fetches the repository from the knot via XRPC instead of GitHub.
+  Replaces actions/checkout for use in the tangled spindle environment.
+inputs:
+  ref:
+    description: The commit SHA or ref to check out
+    default: ""
+  path:
+    description: Relative path under workspace to place the repository
+    default: ""
+runs:
+  using: node20
+  main: index.ts

--- a/src/policy_engine/bundled-actions-net-only/actions/checkout/index.ts
+++ b/src/policy_engine/bundled-actions-net-only/actions/checkout/index.ts
@@ -1,0 +1,94 @@
+// Net-only variant of tangled/checkout.
+//
+// Delegates all filesystem operations to the POLICY_ENGINE_FS_API_URL server
+// (started by the policy engine when --fs-api is set) instead of calling
+// Deno.mkdir / Deno.writeFile directly, allowing the action to run inside the
+// permission-restricted worker where real FS access is blocked.
+
+const knot = Deno.env.get("SPINDLE_KNOT") ?? "";
+const repoDid = Deno.env.get("SPINDLE_REPO_DID") ?? "";
+const ref = Deno.env.get("INPUT_REF") || (Deno.env.get("GITHUB_SHA") ?? "");
+const dest = Deno.env.get("INPUT_PATH") || ".";
+const fsApiUrl = (Deno.env.get("POLICY_ENGINE_FS_API_URL") ?? "").replace(/\/$/, "");
+
+if (!knot || !repoDid || !ref) {
+  console.error(
+    "::error::tangled/checkout: SPINDLE_KNOT, SPINDLE_REPO_DID, and GITHUB_SHA must be set",
+  );
+  Deno.exit(1);
+}
+
+if (!fsApiUrl) {
+  console.error(
+    "::error::tangled/checkout (net-only): POLICY_ENGINE_FS_API_URL must be set — start the engine with --fs-api",
+  );
+  Deno.exit(1);
+}
+
+const knotUrl = knot.startsWith("http") ? knot : `https://${knot}`;
+
+interface TreeEntry {
+  mode: string;
+  name: string;
+}
+
+const DIR_MODE = "0040000";
+
+async function fetchTree(subpath: string): Promise<string[]> {
+  const treeUrl =
+    `${knotUrl}/xrpc/sh.tangled.repo.tree?repo=${encodeURIComponent(repoDid)}&ref=${encodeURIComponent(ref)}&path=${encodeURIComponent(subpath)}`;
+  const resp = await fetch(treeUrl);
+  if (!resp.ok) {
+    throw new Error(`failed to list tree at "${subpath}": ${resp.status} ${resp.statusText}`);
+  }
+  const data = await resp.json();
+  const entries: TreeEntry[] = data.files ?? [];
+
+  const filePaths: string[] = [];
+  const subtrees: Promise<string[]>[] = [];
+
+  for (const entry of entries) {
+    const fullpath = subpath ? `${subpath}/${entry.name}` : entry.name;
+    if (entry.mode === DIR_MODE) {
+      subtrees.push(fetchTree(fullpath));
+    } else {
+      filePaths.push(fullpath);
+    }
+  }
+
+  const nested = await Promise.all(subtrees);
+  for (const paths of nested) filePaths.push(...paths);
+  return filePaths;
+}
+
+async function fsApiMkdir(path: string): Promise<void> {
+  const resp = await fetch(`${fsApiUrl}/mkdir?path=${encodeURIComponent(path)}`, { method: "POST" });
+  if (!resp.ok) throw new Error(`mkdir ${path}: ${resp.status} ${await resp.text()}`);
+}
+
+async function fsApiWriteFile(path: string, body: Uint8Array): Promise<void> {
+  const resp = await fetch(`${fsApiUrl}/file?path=${encodeURIComponent(path)}`, {
+    method: "PUT",
+    body,
+  });
+  if (!resp.ok) throw new Error(`write ${path}: ${resp.status} ${await resp.text()}`);
+}
+
+async function fetchAndWriteFile(fullpath: string): Promise<void> {
+  const blobUrl =
+    `${knotUrl}/xrpc/sh.tangled.repo.blob?repo=${encodeURIComponent(repoDid)}&ref=${encodeURIComponent(ref)}&path=${encodeURIComponent(fullpath)}&raw=true`;
+  const resp = await fetch(blobUrl);
+  if (!resp.ok) {
+    throw new Error(`failed to fetch blob "${fullpath}": ${resp.status} ${resp.statusText}`);
+  }
+  const destPath = `${dest}/${fullpath}`;
+  const body = new Uint8Array(await resp.arrayBuffer());
+  await fsApiWriteFile(destPath, body);
+}
+
+await fsApiMkdir(dest);
+
+const filePaths = await fetchTree("");
+await Promise.all(filePaths.map((p) => fetchAndWriteFile(p)));
+
+console.log(`Checked out ${ref} from ${knotUrl} (${filePaths.length} files)`);

--- a/src/policy_engine/bundled-actions-net-only/dorny/paths-filter/action.yml
+++ b/src/policy_engine/bundled-actions-net-only/dorny/paths-filter/action.yml
@@ -1,0 +1,28 @@
+name: Paths Filter
+description: >
+  Filters changed files by path patterns and sets outputs for each filter.
+  Drop-in replacement for dorny/paths-filter using the tangled knot XRPC API.
+inputs:
+  filters:
+    description: >
+      YAML map of filter names to glob pattern lists. Example:
+        src:
+          - 'src/**'
+        docs:
+          - 'docs/**'
+    required: true
+  base:
+    description: Base ref to compare against
+    default: main
+  ref:
+    description: Current ref (defaults to GITHUB_SHA)
+    default: ""
+outputs:
+  changes:
+    description: >
+      JSON object mapping filter names to booleans.
+      Example: {"src": true, "docs": false}
+    value: ${{ steps.filter.outputs.changes }}
+runs:
+  using: node20
+  main: index.ts

--- a/src/policy_engine/bundled-actions-net-only/dorny/paths-filter/index.ts
+++ b/src/policy_engine/bundled-actions-net-only/dorny/paths-filter/index.ts
@@ -1,0 +1,92 @@
+// Net-only variant of dorny/paths-filter.
+//
+// Differences from the standard variant:
+//   - Uses dynamic import() for @std/yaml and @std/path so they work after
+//     the policy-engine shim is prepended (static top-level imports must be
+//     first in a module, but the shim is injected before the action source).
+//   - Writes GITHUB_OUTPUT via the virtual FS shim (Deno.writeTextFile to the
+//     sentinel path is intercepted) — no FS API needed for outputs.
+//   - The import: true worker permission is required; the engine sets this
+//     automatically when allowNet is true.
+
+const { parse } = await import("jsr:@std/yaml");
+const { globToRegExp } = await import("jsr:@std/path/posix");
+
+const knot = Deno.env.get("SPINDLE_KNOT") ?? "";
+const repoDid = Deno.env.get("SPINDLE_REPO_DID") ?? "";
+const inputBase = Deno.env.get("INPUT_BASE") ?? "";
+const currRef = Deno.env.get("INPUT_REF") || (Deno.env.get("GITHUB_SHA") ?? "");
+const filtersYaml = Deno.env.get("INPUT_FILTERS") ?? "";
+const githubOutput = Deno.env.get("GITHUB_OUTPUT") ?? "";
+
+if (!knot || !repoDid || !currRef || !filtersYaml) {
+  console.error(
+    "::error::paths-filter: SPINDLE_KNOT, SPINDLE_REPO_DID, GITHUB_SHA, and filters input required",
+  );
+  Deno.exit(1);
+}
+
+const knotUrl = knot.startsWith("http") ? knot : `https://${knot}`;
+
+interface TangledCommit {
+  hash?: string;
+  this?: string;
+}
+
+function commitHash(commit: TangledCommit): string | undefined {
+  return typeof commit.hash === "string" ? commit.hash : commit.this;
+}
+
+async function findPreviousCommit(ref: string): Promise<string> {
+  const listUrl =
+    `${knotUrl}/xrpc/sh.tangled.git.temp.listCommits?repo=${encodeURIComponent(repoDid)}&ref=${encodeURIComponent(ref)}&limit=2`;
+  const resp = await fetch(listUrl);
+  if (!resp.ok) {
+    console.error(
+      `::error::paths-filter: failed to discover previous commit for "${ref}": ${resp.status} ${resp.statusText}`,
+    );
+    Deno.exit(1);
+  }
+  const data = await resp.json();
+  const commits: TangledCommit[] = data.commits ?? [];
+  const previous = commits[1] && commitHash(commits[1]);
+  if (!previous) {
+    console.error(`::error::paths-filter: "${ref}" has no previous commit to compare against`);
+    Deno.exit(1);
+  }
+  return previous;
+}
+
+const baseRef = inputBase || (await findPreviousCommit(currRef));
+
+const compareUrl =
+  `${knotUrl}/xrpc/sh.tangled.repo.compare?repo=${encodeURIComponent(repoDid)}&rev1=${encodeURIComponent(baseRef)}&rev2=${encodeURIComponent(currRef)}`;
+
+const resp = await fetch(compareUrl);
+if (!resp.ok) {
+  console.error(
+    `::error::paths-filter: failed to fetch changed files: ${resp.status} ${resp.statusText}`,
+  );
+  Deno.exit(1);
+}
+
+const data = await resp.json();
+const changedFiles: string[] = (data.files ?? []).map((f: { path: string }) => f.path);
+
+const filters = parse(filtersYaml) as Record<string, string[]>;
+
+const results: Record<string, boolean> = {};
+for (const [name, patterns] of Object.entries(filters)) {
+  const patternList = Array.isArray(patterns) ? patterns : [patterns];
+  results[name] = changedFiles.some((file) =>
+    patternList.some((pattern) =>
+      globToRegExp(pattern, { extended: true, globstar: true }).test(file)
+    )
+  );
+}
+
+if (githubOutput) {
+  for (const [key, value] of Object.entries(results)) {
+    await Deno.writeTextFile(githubOutput, `${key}=${value}\n`, { append: true });
+  }
+}

--- a/src/policy_engine/ts/README.md
+++ b/src/policy_engine/ts/README.md
@@ -1,59 +1,85 @@
 # Policy Engine (TypeScript / Deno + Hono)
 
-A TypeScript implementation of the policy engine — GitHub Actions workflow
-evaluation — built on [Deno](https://deno.com) and [Hono](https://hono.dev).
-It is a port of the Go implementation in [`../common`](../common), exposing the
-same HTTP API and execution semantics.
+A TypeScript implementation of the policy engine — GitHub Actions workflow evaluation — built on
+[Deno](https://deno.com) and [Hono](https://hono.dev). It is a port of the Go implementation in
+[`../common`](../common), exposing the same HTTP API and execution semantics.
 
 ## Layout
 
-| File | Purpose |
-| --- | --- |
-| `main.ts` | CLI entrypoint (`api` and `run` commands) |
-| `src/models.ts` | Request/response types, `Task`, `TaskManager`, execution context |
+| File              | Purpose                                                                            |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| `main.ts`         | CLI entrypoint (`api` and `run` commands)                                          |
+| `src/models.ts`   | Request/response types, `Task`, `TaskManager`, execution context                   |
 | `src/workflow.ts` | Workflow executor: expression evaluation, `run`/`uses` steps, outputs, annotations |
-| `src/server.ts` | Hono app: request lifecycle, console output (plain + SSE), webhook, health |
-| `src/logger.ts` | Leveled logging (`POLICY_ENGINE_LOG_LEVEL`) |
+| `src/eval.ts`     | Native sandboxed expression evaluator (permission-restricted Worker)               |
+| `src/config.ts`   | Sandbox configuration (full vs. net-only)                                          |
+| `src/server.ts`   | Hono app: request lifecycle, console output (plain + SSE), webhook, health         |
+| `src/logger.ts`   | Leveled logging (`POLICY_ENGINE_LOG_LEVEL`)                                        |
+
+> **Note:** the engine evaluates expressions in a permission-restricted Web Worker, which requires
+> Deno's `--unstable-worker-options` flag. It is baked into the shebang and the `deno task`
+> definitions; pass it explicitly if you invoke `deno run` yourself.
 
 ## Running
 
 ```bash
 # Start the HTTP API server (default 127.0.0.1:8080)
 deno task api
-deno run --allow-all main.ts api --bind 0.0.0.0:9090
-deno run --allow-all main.ts api --bind unix:/tmp/pe.sock
+deno task api --bind 0.0.0.0:9090
+deno task api --bind unix:/tmp/pe.sock
 
 # Execute a workflow locally and print the status JSON
-deno run --allow-all main.ts run --workflow ./workflow.yml --repository acme/widgets
-deno run --allow-all main.ts run --workflow 'name: t
+deno task run --workflow ./workflow.yml --repository acme/widgets
+deno task run --workflow 'name: t
 on: push
 jobs:
   j:
     runs-on: self-hosted
     steps:
     - run: echo hi' --input name=test
+
+# Equivalent raw invocation (note the unstable flag)
+deno run --allow-all --unstable-worker-options main.ts api --bind 0.0.0.0:9090
 ```
 
 ## HTTP API
 
-| Method | Path | Description |
-| --- | --- | --- |
-| `POST` | `/request/create` | Submit a workflow; returns `{status: submitted, detail: {id}}` |
-| `GET` | `/request/status/:id` | Poll request status |
-| `GET` | `/request/console_output/:id` | Full console output (text) |
-| `GET` | `/request/console_output_stream/:id` | Console output as Server-Sent Events |
-| `POST` | `/webhook/github` | GitHub `push` / `pull_request` webhook receiver |
-| `GET` | `/rate_limit` | GitHub-API-compatible rate limit stub |
-| `GET` | `/health` | Health check |
+| Method | Path                                 | Description                                                    |
+| ------ | ------------------------------------ | -------------------------------------------------------------- |
+| `POST` | `/request/create`                    | Submit a workflow; returns `{status: submitted, detail: {id}}` |
+| `GET`  | `/request/status/:id`                | Poll request status                                            |
+| `GET`  | `/request/console_output/:id`        | Full console output (text)                                     |
+| `GET`  | `/request/console_output_stream/:id` | Console output as Server-Sent Events                           |
+| `POST` | `/webhook/github`                    | GitHub `push` / `pull_request` webhook receiver                |
+| `GET`  | `/rate_limit`                        | GitHub-API-compatible rate limit stub                          |
+| `GET`  | `/health`                            | Health check                                                   |
 
-## Expression evaluation
+## Expression evaluation & sandboxing
 
-`${{ ... }}` expressions are evaluated as JavaScript via a sandboxed `deno run`
-subprocess, with the `github`, `runner`, `steps`, and `inputs` contexts in
-scope (matching the Go/Python implementations). Step outputs stored as the
-strings `"true"`/`"false"` are coerced to real booleans so comparisons like
-`steps.x.outputs.y === true` behave as expected. Unresolved conditions fail
-closed.
+`${{ ... }}` expressions are evaluated as JavaScript with the `github`, `runner`, `steps`, and
+`inputs` contexts in scope. Step outputs stored as the strings `"true"`/`"false"` are coerced to
+real booleans so comparisons like `steps.x.outputs.y === true` behave as expected. Unresolved
+conditions fail closed.
+
+Evaluation **never shells out to the `deno` binary**. Instead each expression runs inside a
+long-lived, in-process Web Worker whose Deno permissions are locked down. Even though the host
+process may run with `--allow-all`, the worker can only do what its permission set allows:
+
+| Mode             | Worker permissions            | `run` / `uses` steps | Filesystem               |
+| ---------------- | ----------------------------- | -------------------- | ------------------------ |
+| `full` (default) | none (no net, no FS, no exec) | executed normally    | ephemeral workspace/temp |
+| `net-only`       | network only                  | **refused**          | **never touched**        |
+
+In `net-only` mode the engine is a pure policy evaluator: expressions may make network calls (and
+nothing else), and any step that would require the filesystem or process execution is rejected with
+a clear error. This is enabled with the `--net-only` CLI flag or the `POLICY_ENGINE_NET_ONLY`
+environment variable.
+
+```bash
+# Strict network-only sandbox — never touches the filesystem, never execs
+deno task api --net-only
+POLICY_ENGINE_NET_ONLY=1 deno task api
+```
 
 ## Action resolution (`uses`)
 
@@ -62,8 +88,8 @@ closed.
 3. Bundled actions dir (`BUNDLED_ACTIONS_DIR`)
 4. Download from GitHub (cached under `.cache/<org>/<repo>`)
 
-Node actions run through Deno's Node compatibility layer; composite actions run
-their `run` steps in sequence.
+Node actions run through Deno's Node compatibility layer; composite actions run their `run` steps in
+sequence.
 
 ## Tests
 
@@ -73,8 +99,9 @@ deno task test
 
 ## Environment variables
 
-| Variable | Effect |
-| --- | --- |
-| `POLICY_ENGINE_LOG_LEVEL` | `trace` / `debug` / `info` (default) / `warn` / `error` |
-| `BUNDLED_ACTIONS_DIR` | Directory of pre-bundled actions |
-| `DEBUG_DENO_PACKAGES` | Set to `1` to show Deno package download messages |
+| Variable                  | Effect                                                      |
+| ------------------------- | ----------------------------------------------------------- |
+| `POLICY_ENGINE_LOG_LEVEL` | `trace` / `debug` / `info` (default) / `warn` / `error`     |
+| `POLICY_ENGINE_NET_ONLY`  | Set truthy (`1`/`true`) for the strict network-only sandbox |
+| `BUNDLED_ACTIONS_DIR`     | Directory of pre-bundled actions                            |
+| `DEBUG_DENO_PACKAGES`     | Set to `1` to show Deno package download messages           |

--- a/src/policy_engine/ts/README.md
+++ b/src/policy_engine/ts/README.md
@@ -1,0 +1,80 @@
+# Policy Engine (TypeScript / Deno + Hono)
+
+A TypeScript implementation of the policy engine — GitHub Actions workflow
+evaluation — built on [Deno](https://deno.com) and [Hono](https://hono.dev).
+It is a port of the Go implementation in [`../common`](../common), exposing the
+same HTTP API and execution semantics.
+
+## Layout
+
+| File | Purpose |
+| --- | --- |
+| `main.ts` | CLI entrypoint (`api` and `run` commands) |
+| `src/models.ts` | Request/response types, `Task`, `TaskManager`, execution context |
+| `src/workflow.ts` | Workflow executor: expression evaluation, `run`/`uses` steps, outputs, annotations |
+| `src/server.ts` | Hono app: request lifecycle, console output (plain + SSE), webhook, health |
+| `src/logger.ts` | Leveled logging (`POLICY_ENGINE_LOG_LEVEL`) |
+
+## Running
+
+```bash
+# Start the HTTP API server (default 127.0.0.1:8080)
+deno task api
+deno run --allow-all main.ts api --bind 0.0.0.0:9090
+deno run --allow-all main.ts api --bind unix:/tmp/pe.sock
+
+# Execute a workflow locally and print the status JSON
+deno run --allow-all main.ts run --workflow ./workflow.yml --repository acme/widgets
+deno run --allow-all main.ts run --workflow 'name: t
+on: push
+jobs:
+  j:
+    runs-on: self-hosted
+    steps:
+    - run: echo hi' --input name=test
+```
+
+## HTTP API
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/request/create` | Submit a workflow; returns `{status: submitted, detail: {id}}` |
+| `GET` | `/request/status/:id` | Poll request status |
+| `GET` | `/request/console_output/:id` | Full console output (text) |
+| `GET` | `/request/console_output_stream/:id` | Console output as Server-Sent Events |
+| `POST` | `/webhook/github` | GitHub `push` / `pull_request` webhook receiver |
+| `GET` | `/rate_limit` | GitHub-API-compatible rate limit stub |
+| `GET` | `/health` | Health check |
+
+## Expression evaluation
+
+`${{ ... }}` expressions are evaluated as JavaScript via a sandboxed `deno run`
+subprocess, with the `github`, `runner`, `steps`, and `inputs` contexts in
+scope (matching the Go/Python implementations). Step outputs stored as the
+strings `"true"`/`"false"` are coerced to real booleans so comparisons like
+`steps.x.outputs.y === true` behave as expected. Unresolved conditions fail
+closed.
+
+## Action resolution (`uses`)
+
+1. Local path (`./path` or `/abs/path`)
+2. Repo-supplied actions dir (`ACTIONS_DIR`, default `<workspace>/.tangled/actions`)
+3. Bundled actions dir (`BUNDLED_ACTIONS_DIR`)
+4. Download from GitHub (cached under `.cache/<org>/<repo>`)
+
+Node actions run through Deno's Node compatibility layer; composite actions run
+their `run` steps in sequence.
+
+## Tests
+
+```bash
+deno task test
+```
+
+## Environment variables
+
+| Variable | Effect |
+| --- | --- |
+| `POLICY_ENGINE_LOG_LEVEL` | `trace` / `debug` / `info` (default) / `warn` / `error` |
+| `BUNDLED_ACTIONS_DIR` | Directory of pre-bundled actions |
+| `DEBUG_DENO_PACKAGES` | Set to `1` to show Deno package download messages |

--- a/src/policy_engine/ts/README.md
+++ b/src/policy_engine/ts/README.md
@@ -6,15 +6,16 @@ A TypeScript implementation of the policy engine — GitHub Actions workflow eva
 
 ## Layout
 
-| File              | Purpose                                                                            |
-| ----------------- | ---------------------------------------------------------------------------------- |
-| `main.ts`         | CLI entrypoint (`api` and `run` commands)                                          |
-| `src/models.ts`   | Request/response types, `Task`, `TaskManager`, execution context                   |
-| `src/workflow.ts` | Workflow executor: expression evaluation, `run`/`uses` steps, outputs, annotations |
-| `src/eval.ts`     | Native sandboxed expression evaluator (permission-restricted Worker)               |
-| `src/config.ts`   | Sandbox configuration (full vs. net-only)                                          |
-| `src/server.ts`   | Hono app: request lifecycle, console output (plain + SSE), webhook, health         |
-| `src/logger.ts`   | Leveled logging (`POLICY_ENGINE_LOG_LEVEL`)                                        |
+| File                   | Purpose                                                                            |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| `main.ts`              | CLI entrypoint (`api` and `run` commands)                                          |
+| `src/models.ts`        | Request/response types, `Task`, `TaskManager`, execution context                   |
+| `src/workflow.ts`      | Workflow executor: expression evaluation, `run`/`uses` steps, outputs, annotations |
+| `src/eval.ts`          | Native sandboxed expression evaluator (permission-restricted Worker)               |
+| `src/action_worker.ts` | Native sandboxed runner for JS/TS `uses` actions (permission-restricted Worker)    |
+| `src/config.ts`        | Sandbox configuration (full vs. net-only)                                          |
+| `src/server.ts`        | Hono app: request lifecycle, console output (plain + SSE), webhook, health         |
+| `src/logger.ts`        | Leveled logging (`POLICY_ENGINE_LOG_LEVEL`)                                        |
 
 > **Note:** the engine evaluates expressions in a permission-restricted Web Worker, which requires
 > Deno's `--unstable-worker-options` flag. It is baked into the shebang and the `deno task`
@@ -65,15 +66,34 @@ Evaluation **never shells out to the `deno` binary**. Instead each expression ru
 long-lived, in-process Web Worker whose Deno permissions are locked down. Even though the host
 process may run with `--allow-all`, the worker can only do what its permission set allows:
 
-| Mode             | Worker permissions            | `run` / `uses` steps | Filesystem               |
-| ---------------- | ----------------------------- | -------------------- | ------------------------ |
-| `full` (default) | none (no net, no FS, no exec) | executed normally    | ephemeral workspace/temp |
-| `net-only`       | network only                  | **refused**          | **never touched**        |
+| Mode             | Expression worker             | JS/TS `uses` actions           | `run` / composite steps | Host filesystem |
+| ---------------- | ----------------------------- | ------------------------------ | ----------------------- | --------------- |
+| `full` (default) | none (no net, no FS, no exec) | full Deno subprocess           | executed normally       | ephemeral dirs  |
+| `net-only`       | network only                  | sandboxed worker, network only | **refused**             | **no writes**   |
 
-In `net-only` mode the engine is a pure policy evaluator: expressions may make network calls (and
-nothing else), and any step that would require the filesystem or process execution is rejected with
-a clear error. This is enabled with the `--net-only` CLI flag or the `POLICY_ENGINE_NET_ONLY`
-environment variable.
+In `net-only` mode the engine is a pure, network-only policy evaluator: expressions and
+JavaScript/TypeScript actions may make network calls and nothing else. It is enabled with the
+`--net-only` CLI flag or the `POLICY_ENGINE_NET_ONLY` environment variable.
+
+### JS/TS actions in net-only mode
+
+`uses:` actions written as Deno-native / ESM TypeScript or JavaScript run **inside the same
+permission-restricted worker** rather than shelling out to a full `deno run` subprocess. The action
+gets network access only — it cannot read or write the real filesystem or spawn processes. To make
+this transparent:
+
+- action **inputs** (`INPUT_*`, `GITHUB_*`) are injected via a `Deno.env` shim, so the action needs
+  no environment access and never sees the host's env;
+- writes to the `GITHUB_OUTPUT` / `GITHUB_ENV` / `GITHUB_PATH` / `GITHUB_STATE` command files are
+  captured into an **in-memory virtual filesystem** and parsed back out as step outputs and env
+  updates;
+- `Deno.exit` is contained so an action cannot terminate the host;
+- `console.*` output is streamed line-by-line (including `::error`/`::warning` annotations).
+
+Because there is no filesystem in net-only mode, actions must be supplied via a local path,
+`ACTIONS_DIR`, or `BUNDLED_ACTIONS_DIR` (downloading is disabled), and CommonJS/ncc bundles that
+rely on `require` are not supported there — use the default sandbox for those. `run` steps and
+composite actions (which need a shell) are refused in net-only mode.
 
 ```bash
 # Strict network-only sandbox — never touches the filesystem, never execs
@@ -88,8 +108,10 @@ POLICY_ENGINE_NET_ONLY=1 deno task api
 3. Bundled actions dir (`BUNDLED_ACTIONS_DIR`)
 4. Download from GitHub (cached under `.cache/<org>/<repo>`)
 
-Node actions run through Deno's Node compatibility layer; composite actions run their `run` steps in
-sequence.
+In the default sandbox, node actions run through Deno's Node compatibility layer (a `deno run`
+subprocess, supporting CommonJS/ncc bundles) and composite actions run their `run` steps in
+sequence. In `net-only` mode, JS/TS actions run in the permission-restricted worker instead (see
+above).
 
 ## Tests
 

--- a/src/policy_engine/ts/deno.json
+++ b/src/policy_engine/ts/deno.json
@@ -1,0 +1,19 @@
+{
+  "name": "policy-engine",
+  "version": "0.1.0",
+  "exports": "./main.ts",
+  "tasks": {
+    "api": "deno run --allow-all main.ts api",
+    "test": "deno test --allow-all"
+  },
+  "imports": {
+    "hono": "jsr:@hono/hono@^4.6.0",
+    "@std/yaml": "jsr:@std/yaml@^1.0.0",
+    "@std/uuid": "jsr:@std/uuid@^1.0.0",
+    "@std/fs": "jsr:@std/fs@^1.0.0",
+    "@std/path": "jsr:@std/path@^1.0.0"
+  },
+  "fmt": {
+    "lineWidth": 100
+  }
+}

--- a/src/policy_engine/ts/deno.json
+++ b/src/policy_engine/ts/deno.json
@@ -3,11 +3,13 @@
   "version": "0.1.0",
   "exports": "./main.ts",
   "tasks": {
-    "api": "deno run --allow-all main.ts api",
-    "test": "deno test --allow-all"
+    "api": "deno run --allow-all --unstable-worker-options main.ts api",
+    "run": "deno run --allow-all --unstable-worker-options main.ts run",
+    "test": "deno test --allow-all --unstable-worker-options"
   },
   "imports": {
     "hono": "jsr:@hono/hono@^4.6.0",
+    "@std/assert": "jsr:@std/assert@^1.0.0",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "@std/yaml": "jsr:@std/yaml@^1.0.0",
     "@std/uuid": "jsr:@std/uuid@^1.0.0",

--- a/src/policy_engine/ts/deno.json
+++ b/src/policy_engine/ts/deno.json
@@ -8,6 +8,7 @@
   },
   "imports": {
     "hono": "jsr:@hono/hono@^4.6.0",
+    "@std/cli": "jsr:@std/cli@^1.0.0",
     "@std/yaml": "jsr:@std/yaml@^1.0.0",
     "@std/uuid": "jsr:@std/uuid@^1.0.0",
     "@std/fs": "jsr:@std/fs@^1.0.0",

--- a/src/policy_engine/ts/deno.lock
+++ b/src/policy_engine/ts/deno.lock
@@ -38,6 +38,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@hono/hono@^4.6.0",
+      "jsr:@std/assert@1",
       "jsr:@std/cli@1",
       "jsr:@std/fs@1",
       "jsr:@std/path@1",

--- a/src/policy_engine/ts/deno.lock
+++ b/src/policy_engine/ts/deno.lock
@@ -2,7 +2,9 @@
   "version": "5",
   "specifiers": {
     "jsr:@hono/hono@^4.6.0": "4.12.23",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/cli@1": "1.0.30",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@std/internal@^1.0.14": "1.0.14",
     "jsr:@std/path@1": "1.1.5",
     "jsr:@std/yaml@1": "1.1.1"
@@ -10,6 +12,12 @@
   "jsr": {
     "@hono/hono@4.12.23": {
       "integrity": "9d9f3da498f69c311b5f92d973eb3b8ebc973b5fd2b4972781b556e07818a745"
+    },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
     },
     "@std/cli@1.0.30": {
       "integrity": "769446536522d0417d7127ebcabcafac1ab0ce6766d0eb3fca1d36326fe98d13"
@@ -20,7 +28,7 @@
     "@std/path@1.1.5": {
       "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.14"
       ]
     },
     "@std/yaml@1.1.1": {

--- a/src/policy_engine/ts/deno.lock
+++ b/src/policy_engine/ts/deno.lock
@@ -1,0 +1,40 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@hono/hono@^4.6.0": "4.12.23",
+    "jsr:@std/cli@1": "1.0.30",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@1": "1.1.5",
+    "jsr:@std/yaml@1": "1.1.1"
+  },
+  "jsr": {
+    "@hono/hono@4.12.23": {
+      "integrity": "9d9f3da498f69c311b5f92d973eb3b8ebc973b5fd2b4972781b556e07818a745"
+    },
+    "@std/cli@1.0.30": {
+      "integrity": "769446536522d0417d7127ebcabcafac1ab0ce6766d0eb3fca1d36326fe98d13"
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/path@1.1.5": {
+      "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/yaml@1.1.1": {
+      "integrity": "a57665ecf3d17b926380593a56625d8a10cc7281802f1e993b5ebc94a48e71f8"
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@hono/hono@^4.6.0",
+      "jsr:@std/cli@1",
+      "jsr:@std/fs@1",
+      "jsr:@std/path@1",
+      "jsr:@std/uuid@1",
+      "jsr:@std/yaml@1"
+    ]
+  }
+}

--- a/src/policy_engine/ts/main.ts
+++ b/src/policy_engine/ts/main.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env -S deno run --allow-all
+// Policy engine CLI entrypoint (Deno + Hono).
+//
+// Usage:
+//   deno run --allow-all main.ts api [--bind 127.0.0.1:8080]
+//   deno run --allow-all main.ts run --workflow <file|inline> [--input k=v ...]
+
+import { parseArgs } from "@std/cli/parse-args";
+import { createApp, parseBind } from "./src/server.ts";
+import { type PolicyEngineRequest } from "./src/models.ts";
+import { WorkflowExecutor } from "./src/workflow.ts";
+import { Info } from "./src/logger.ts";
+
+function usage(): never {
+  console.error(`policy-engine — GitHub Actions workflow evaluation
+
+Commands:
+  api            Start the HTTP API server
+                   --bind <addr>    Address to bind (default 127.0.0.1:8080)
+  run            Execute a workflow locally and print the status JSON
+                   --workflow <s>   Workflow file path or inline YAML (required)
+                   --input k=v      Input pairs (repeatable)
+                   --repository <s> org/repo (sets GITHUB_REPOSITORY)
+`);
+  Deno.exit(2);
+}
+
+async function cmdApi(args: string[]): Promise<void> {
+  const flags = parseArgs(args, { string: ["bind"], default: { bind: "127.0.0.1:8080" } });
+  const { app } = createApp();
+  const opts = parseBind(flags.bind);
+  Info("starting policy engine API server on %s", flags.bind);
+  // deno-lint-ignore no-explicit-any
+  Deno.serve(opts as any, app.fetch);
+}
+
+async function cmdRun(args: string[]): Promise<void> {
+  const flags = parseArgs(args, {
+    string: ["workflow", "repository"],
+    collect: ["input"],
+  });
+  if (!flags.workflow) usage();
+
+  // A workflow value that points at an existing file is read; otherwise it is
+  // treated as inline YAML.
+  let workflow = flags.workflow as string;
+  try {
+    const stat = await Deno.stat(workflow);
+    if (stat.isFile) workflow = await Deno.readTextFile(workflow);
+  } catch {
+    // not a file — treat as inline
+  }
+
+  const inputs: Record<string, unknown> = {};
+  for (const pair of (flags.input as string[] | undefined) ?? []) {
+    const idx = pair.indexOf("=");
+    if (idx >= 0) inputs[pair.slice(0, idx)] = pair.slice(idx + 1);
+  }
+
+  const env: Record<string, unknown> = {};
+  if (flags.repository) env["GITHUB_REPOSITORY"] = flags.repository;
+
+  const request: PolicyEngineRequest = {
+    workflow,
+    inputs,
+    context: { config: { env } },
+  };
+
+  const executor = new WorkflowExecutor();
+  const status = await executor.executeWorkflow(request);
+  console.log(JSON.stringify(status, null, 2));
+
+  const detail = status.detail as { exit_status?: string };
+  if (detail?.exit_status === "failure") Deno.exit(1);
+}
+
+async function main(): Promise<void> {
+  const [command, ...rest] = Deno.args;
+  switch (command) {
+    case "api":
+      await cmdApi(rest);
+      break;
+    case "run":
+      await cmdRun(rest);
+      break;
+    default:
+      usage();
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/policy_engine/ts/main.ts
+++ b/src/policy_engine/ts/main.ts
@@ -1,14 +1,20 @@
-#!/usr/bin/env -S deno run --allow-all
+#!/usr/bin/env -S deno run --allow-all --unstable-worker-options
 // Policy engine CLI entrypoint (Deno + Hono).
 //
+// Expression evaluation runs in an in-process, permission-restricted Web
+// Worker (never a `deno run` subprocess), which requires the
+// --unstable-worker-options flag — already present in the shebang and the
+// deno tasks.
+//
 // Usage:
-//   deno run --allow-all main.ts api [--bind 127.0.0.1:8080]
-//   deno run --allow-all main.ts run --workflow <file|inline> [--input k=v ...]
+//   deno run --allow-all --unstable-worker-options main.ts api [--bind ...] [--net-only]
+//   deno run --allow-all --unstable-worker-options main.ts run --workflow <file|inline> [--net-only]
 
 import { parseArgs } from "@std/cli/parse-args";
 import { createApp, parseBind } from "./src/server.ts";
-import { type PolicyEngineRequest } from "./src/models.ts";
+import type { PolicyEngineRequest } from "./src/models.ts";
 import { WorkflowExecutor } from "./src/workflow.ts";
+import { resolveSandboxConfig } from "./src/config.ts";
 import { Info } from "./src/logger.ts";
 
 function usage(): never {
@@ -17,19 +23,33 @@ function usage(): never {
 Commands:
   api            Start the HTTP API server
                    --bind <addr>    Address to bind (default 127.0.0.1:8080)
+                   --net-only       Strict sandbox: expression eval gets network
+                                    access only; no filesystem, no exec, no
+                                    run/uses steps (env: POLICY_ENGINE_NET_ONLY)
   run            Execute a workflow locally and print the status JSON
                    --workflow <s>   Workflow file path or inline YAML (required)
                    --input k=v      Input pairs (repeatable)
                    --repository <s> org/repo (sets GITHUB_REPOSITORY)
+                   --net-only       See above
 `);
   Deno.exit(2);
 }
 
-async function cmdApi(args: string[]): Promise<void> {
-  const flags = parseArgs(args, { string: ["bind"], default: { bind: "127.0.0.1:8080" } });
-  const { app } = createApp();
+// --net-only resolves to: flag if present, else POLICY_ENGINE_NET_ONLY env var.
+function sandboxFromFlags(flags: { "net-only"?: boolean }) {
+  return resolveSandboxConfig(flags["net-only"] ? true : undefined);
+}
+
+function cmdApi(args: string[]): void {
+  const flags = parseArgs(args, {
+    string: ["bind"],
+    boolean: ["net-only"],
+    default: { bind: "127.0.0.1:8080" },
+  });
+  const sandbox = sandboxFromFlags(flags);
+  const { app } = createApp(sandbox);
   const opts = parseBind(flags.bind);
-  Info("starting policy engine API server on %s", flags.bind);
+  Info("starting policy engine API server on %s (net-only=%v)", flags.bind, sandbox.netOnly);
   // deno-lint-ignore no-explicit-any
   Deno.serve(opts as any, app.fetch);
 }
@@ -37,6 +57,7 @@ async function cmdApi(args: string[]): Promise<void> {
 async function cmdRun(args: string[]): Promise<void> {
   const flags = parseArgs(args, {
     string: ["workflow", "repository"],
+    boolean: ["net-only"],
     collect: ["input"],
   });
   if (!flags.workflow) usage();
@@ -66,7 +87,7 @@ async function cmdRun(args: string[]): Promise<void> {
     context: { config: { env } },
   };
 
-  const executor = new WorkflowExecutor();
+  const executor = new WorkflowExecutor({ sandbox: sandboxFromFlags(flags) });
   const status = await executor.executeWorkflow(request);
   console.log(JSON.stringify(status, null, 2));
 

--- a/src/policy_engine/ts/main.ts
+++ b/src/policy_engine/ts/main.ts
@@ -26,24 +26,30 @@ Commands:
                    --net-only       Strict sandbox: expression eval gets network
                                     access only; no filesystem, no exec, no
                                     run/uses steps (env: POLICY_ENGINE_NET_ONLY)
+                   --fs-api         Start an in-process HTTP filesystem API on a
+                                    random port and inject POLICY_ENGINE_FS_API_URL
+                                    into action workers (env: POLICY_ENGINE_FS_API)
   run            Execute a workflow locally and print the status JSON
                    --workflow <s>   Workflow file path or inline YAML (required)
                    --input k=v      Input pairs (repeatable)
                    --repository <s> org/repo (sets GITHUB_REPOSITORY)
                    --net-only       See above
+                   --fs-api         See above
 `);
   Deno.exit(2);
 }
 
-// --net-only resolves to: flag if present, else POLICY_ENGINE_NET_ONLY env var.
-function sandboxFromFlags(flags: { "net-only"?: boolean }) {
-  return resolveSandboxConfig(flags["net-only"] ? true : undefined);
+function sandboxFromFlags(flags: { "net-only"?: boolean; "fs-api"?: boolean }) {
+  return resolveSandboxConfig({
+    netOnly: flags["net-only"] ? true : undefined,
+    fsApi: flags["fs-api"] ? true : undefined,
+  });
 }
 
 function cmdApi(args: string[]): void {
   const flags = parseArgs(args, {
     string: ["bind"],
-    boolean: ["net-only"],
+    boolean: ["net-only", "fs-api"],
     default: { bind: "127.0.0.1:8080" },
   });
   const sandbox = sandboxFromFlags(flags);
@@ -57,7 +63,7 @@ function cmdApi(args: string[]): void {
 async function cmdRun(args: string[]): Promise<void> {
   const flags = parseArgs(args, {
     string: ["workflow", "repository"],
-    boolean: ["net-only"],
+    boolean: ["net-only", "fs-api"],
     collect: ["input"],
   });
   if (!flags.workflow) usage();

--- a/src/policy_engine/ts/src/action_worker.ts
+++ b/src/policy_engine/ts/src/action_worker.ts
@@ -1,0 +1,192 @@
+// Native, sandboxed runner for JavaScript/TypeScript GitHub Actions.
+//
+// Instead of shelling out to `deno run --allow-all <action>` (full, unsandboxed
+// process execution), this runs a Deno-native / ESM action's source inside an
+// in-process Web Worker whose Deno permissions are locked down — the same
+// mechanism used for expression evaluation. The action receives network access
+// only (in net-only mode); it cannot read or write the real filesystem or spawn
+// subprocesses. Action inputs are injected via a `Deno.env` shim (so no real
+// environment access is needed), and writes to the GITHUB_OUTPUT / GITHUB_ENV /
+// GITHUB_PATH / GITHUB_STATE command files are captured into an in-memory
+// virtual filesystem and returned to the host.
+//
+// Requires the `--unstable-worker-options` flag (baked into the CLI shebang and
+// the deno tasks).
+
+/** Result of running an action in the sandboxed worker. */
+export interface ActionRunResult {
+  /** Process-style exit code (0 = success). */
+  code: number;
+  /** Captured contents of the GITHUB_OUTPUT command file. */
+  output: string;
+  /** Captured contents of the GITHUB_ENV command file. */
+  env: string;
+}
+
+// Sentinel "paths" used as the GITHUB_* command-file locations. The action
+// writes to these via Deno.writeTextFile; the shim intercepts them into an
+// in-memory map rather than touching the real filesystem.
+const SENTINELS = {
+  GITHUB_OUTPUT: "pe-virtual:GITHUB_OUTPUT",
+  GITHUB_ENV: "pe-virtual:GITHUB_ENV",
+  GITHUB_PATH: "pe-virtual:GITHUB_PATH",
+  GITHUB_STATE: "pe-virtual:GITHUB_STATE",
+} as const;
+
+/** Build the prelude injected ahead of the action source inside the worker. */
+function buildShim(env: Record<string, string>): string {
+  return `
+const __pe_env = ${JSON.stringify(env)};
+const __pe_vfs = {};
+const __pe_ghPaths = new Set(
+  [__pe_env.GITHUB_OUTPUT, __pe_env.GITHUB_ENV, __pe_env.GITHUB_PATH, __pe_env.GITHUB_STATE]
+    .filter((v) => typeof v === "string" && v.length > 0),
+);
+
+// Inject inputs through a Deno.env shim so the action needs no env permission
+// and never sees the host's real environment.
+Object.defineProperty(Deno, "env", {
+  configurable: true,
+  value: {
+    get: (k) => __pe_env[k],
+    has: (k) => Object.prototype.hasOwnProperty.call(__pe_env, k),
+    set: () => {},
+    delete: () => {},
+    toObject: () => ({ ...__pe_env }),
+  },
+});
+
+// Capture writes to the GITHUB_* command files; delegate everything else to the
+// real implementation, which the permission sandbox will deny.
+const __pe_origWriteText = Deno.writeTextFile.bind(Deno);
+const __pe_origWriteTextSync = Deno.writeTextFileSync.bind(Deno);
+const __pe_origReadText = Deno.readTextFile.bind(Deno);
+const __pe_origReadTextSync = Deno.readTextFileSync.bind(Deno);
+function __pe_append(k, data, opts) {
+  __pe_vfs[k] = (opts && opts.append ? (__pe_vfs[k] || "") : "") + data;
+}
+Deno.writeTextFile = (p, data, opts) => {
+  const k = String(p);
+  if (__pe_ghPaths.has(k)) { __pe_append(k, data, opts); return Promise.resolve(); }
+  return __pe_origWriteText(p, data, opts);
+};
+Deno.writeTextFileSync = (p, data, opts) => {
+  const k = String(p);
+  if (__pe_ghPaths.has(k)) { __pe_append(k, data, opts); return; }
+  return __pe_origWriteTextSync(p, data, opts);
+};
+Deno.readTextFile = (p, opts) => {
+  const k = String(p);
+  if (__pe_ghPaths.has(k)) return Promise.resolve(__pe_vfs[k] || "");
+  return __pe_origReadText(p, opts);
+};
+Deno.readTextFileSync = (p) => {
+  const k = String(p);
+  if (__pe_ghPaths.has(k)) return __pe_vfs[k] || "";
+  return __pe_origReadTextSync(p);
+};
+
+// Contain Deno.exit so the action cannot terminate the host process.
+Deno.exit = (code = 0) => {
+  self.postMessage({ k: "exit", code: typeof code === "number" ? code : 0, vfs: __pe_vfs });
+  self.close();
+};
+
+// Stream console output back to the host line-by-line.
+for (const m of ["log", "error", "warn", "info", "debug"]) {
+  console[m] = (...args) =>
+    self.postMessage({ k: "log", line: args.map((a) => typeof a === "string" ? a : Deno.inspect(a)).join(" ") });
+}
+
+self.addEventListener("error", (e) => {
+  e.preventDefault();
+  self.postMessage({ k: "log", line: String(e.message) });
+  self.postMessage({ k: "exit", code: 1, vfs: __pe_vfs });
+  self.close();
+});
+self.addEventListener("unhandledrejection", (e) => {
+  e.preventDefault();
+  self.postMessage({ k: "log", line: String(e.reason && e.reason.stack || e.reason) });
+  self.postMessage({ k: "exit", code: 1, vfs: __pe_vfs });
+  self.close();
+});
+`;
+}
+
+// Footer appended after the action source; runs only if the action neither
+// called Deno.exit nor threw, signalling clean completion.
+const FOOTER = `
+;self.postMessage({ k: "exit", code: 0, vfs: __pe_vfs });
+`;
+
+/**
+ * Run a JS/TS action's source inside the permission-restricted worker.
+ * The provided env (including INPUT_* values) is injected; GITHUB_OUTPUT and
+ * GITHUB_ENV command-file writes are captured and returned.
+ */
+export function runActionInWorker(opts: {
+  source: string;
+  env: Record<string, string>;
+  allowNet: boolean;
+  onLine?: (line: string) => void;
+}): Promise<ActionRunResult> {
+  // Point the GITHUB_* command files at in-memory sentinels.
+  const env: Record<string, string> = {
+    ...opts.env,
+    GITHUB_OUTPUT: SENTINELS.GITHUB_OUTPUT,
+    GITHUB_ENV: SENTINELS.GITHUB_ENV,
+    GITHUB_PATH: SENTINELS.GITHUB_PATH,
+    GITHUB_STATE: SENTINELS.GITHUB_STATE,
+  };
+
+  // @ts-nocheck disables type-checking for the worker module: action code is
+  // untrusted and must run as-is (like `deno run`), never gated on type errors.
+  const moduleSource = "// @ts-nocheck\n" + buildShim(env) + "\n" + opts.source + "\n" + FOOTER;
+  const blobUrl = URL.createObjectURL(
+    new Blob([moduleSource], { type: "text/typescript" }),
+  );
+  const worker = new Worker(blobUrl, {
+    type: "module",
+    deno: {
+      permissions: {
+        net: opts.allowNet ? true : false,
+        read: false,
+        write: false,
+        run: false,
+        env: false,
+        sys: false,
+        ffi: false,
+        import: false,
+      },
+    },
+  });
+
+  return new Promise<ActionRunResult>((resolve, reject) => {
+    worker.onmessage = (e: MessageEvent) => {
+      const d = e.data as {
+        k?: string;
+        line?: string;
+        code?: number;
+        vfs?: Record<string, string>;
+      };
+      if (d.k === "log") {
+        opts.onLine?.(d.line ?? "");
+      } else if (d.k === "exit") {
+        const vfs = d.vfs ?? {};
+        worker.terminate();
+        URL.revokeObjectURL(blobUrl);
+        resolve({
+          code: d.code ?? 0,
+          output: vfs[SENTINELS.GITHUB_OUTPUT] ?? "",
+          env: vfs[SENTINELS.GITHUB_ENV] ?? "",
+        });
+      }
+    };
+    worker.onerror = (e: ErrorEvent) => {
+      e.preventDefault();
+      worker.terminate();
+      URL.revokeObjectURL(blobUrl);
+      reject(new Error(`action worker error: ${e.message}`));
+    };
+  });
+}

--- a/src/policy_engine/ts/src/action_worker.ts
+++ b/src/policy_engine/ts/src/action_worker.ts
@@ -156,7 +156,9 @@ export function runActionInWorker(opts: {
         env: false,
         sys: false,
         ffi: false,
-        import: false,
+        // Allow JSR/npm imports when network is available so net-only actions
+        // can use dynamic import("jsr:@std/yaml") etc.
+        import: opts.allowNet ? true : false,
       },
     },
   });

--- a/src/policy_engine/ts/src/action_worker_test.ts
+++ b/src/policy_engine/ts/src/action_worker_test.ts
@@ -1,0 +1,140 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { runActionInWorker } from "./action_worker.ts";
+import { WorkflowExecutor } from "./workflow.ts";
+import { join } from "@std/path";
+
+Deno.test("runActionInWorker: injects inputs, captures output and console", async () => {
+  const source = `
+const name = Deno.env.get("INPUT_NAME") ?? "world";
+console.log("hello " + name);
+const out = Deno.env.get("GITHUB_OUTPUT");
+await Deno.writeTextFile(out, "greeting=hi-" + name + "\\n", { append: true });
+`;
+  const lines: string[] = [];
+  const res = await runActionInWorker({
+    source,
+    env: { INPUT_NAME: "deno" },
+    allowNet: false,
+    onLine: (l) => lines.push(l),
+  });
+  assertEquals(res.code, 0);
+  assertEquals(res.output, "greeting=hi-deno\n");
+  assertEquals(lines, ["hello deno"]);
+});
+
+Deno.test("runActionInWorker: blocks real filesystem writes (uncaught -> exit 1)", async () => {
+  const source = `await Deno.writeTextFile("/tmp/pe_should_not_exist", "x");`;
+  const lines: string[] = [];
+  const res = await runActionInWorker({
+    source,
+    env: {},
+    allowNet: false,
+    onLine: (l) => lines.push(l),
+  });
+  assertEquals(res.code, 1);
+  assertStringIncludes(lines.join("\n"), "NotCapable");
+});
+
+Deno.test("runActionInWorker: blocks subprocess execution", async () => {
+  const source = `
+try { new Deno.Command("echo", { args: ["hi"] }).outputSync(); console.log("RAN"); }
+catch (e) { console.log("blocked:" + e.name); }
+`;
+  const lines: string[] = [];
+  const res = await runActionInWorker({
+    source,
+    env: {},
+    allowNet: false,
+    onLine: (l) => lines.push(l),
+  });
+  assertEquals(res.code, 0);
+  assertStringIncludes(lines.join("\n"), "blocked:NotCapable");
+});
+
+Deno.test("runActionInWorker: network is gated by allowNet", async () => {
+  const ac = new AbortController();
+  const server = Deno.serve(
+    { port: 0, signal: ac.signal, onListen: () => {} },
+    () => new Response("pong"),
+  );
+  const port = (server.addr as Deno.NetAddr).port;
+  const url = `http://127.0.0.1:${port}/`;
+
+  try {
+    // With net: succeeds.
+    const ok = await runActionInWorker({
+      source: `const r = await fetch(${
+        JSON.stringify(url)
+      }); console.log("got:" + (await r.text()));`,
+      env: {},
+      allowNet: true,
+    });
+    assertEquals(ok.code, 0);
+
+    // Without net: fetch is denied -> uncaught -> exit 1.
+    const lines: string[] = [];
+    const denied = await runActionInWorker({
+      source: `await fetch(${JSON.stringify(url)});`,
+      env: {},
+      allowNet: false,
+      onLine: (l) => lines.push(l),
+    });
+    assertEquals(denied.code, 1);
+    assertStringIncludes(lines.join("\n"), "NotCapable");
+  } finally {
+    ac.abort();
+    await server.finished;
+  }
+});
+
+Deno.test("WorkflowExecutor: runs a TS uses-action in net-only mode", async () => {
+  // A bundled Deno-native action that fetches and writes a step output.
+  const ac = new AbortController();
+  const server = Deno.serve(
+    { port: 0, signal: ac.signal, onListen: () => {} },
+    () => new Response(JSON.stringify({ value: 42 })),
+  );
+  const port = (server.addr as Deno.NetAddr).port;
+
+  const bundled = await Deno.makeTempDir({ prefix: "pe-bundled-" });
+  const actDir = join(bundled, "test", "act");
+  await Deno.mkdir(actDir, { recursive: true });
+  await Deno.writeTextFile(
+    join(actDir, "action.yml"),
+    `name: Test\ndescription: t\ninputs:\n  endpoint:\n    default: ""\nruns:\n  using: node20\n  main: index.ts\n`,
+  );
+  await Deno.writeTextFile(
+    join(actDir, "index.ts"),
+    `const ep = Deno.env.get("INPUT_ENDPOINT") ?? "";
+const resp = await fetch(ep);
+const data = await resp.json();
+console.log("fetched value " + data.value);
+const out = Deno.env.get("GITHUB_OUTPUT");
+if (out) await Deno.writeTextFile(out, "value=" + data.value + "\\n", { append: true });
+`,
+  );
+
+  Deno.env.set("BUNDLED_ACTIONS_DIR", bundled);
+  try {
+    const executor = new WorkflowExecutor({ sandbox: { netOnly: true } });
+    const status = await executor.executeWorkflow({
+      workflow: `name: t
+on: push
+jobs:
+  j:
+    runs-on: self-hosted
+    steps:
+    - id: a
+      uses: test/act@v1
+      with:
+        endpoint: http://127.0.0.1:${port}/`,
+    });
+    assertEquals((status.detail as { exit_status: string }).exit_status, "success");
+    assertStringIncludes(status.console_output ?? "", "fetched value 42");
+  } finally {
+    Deno.env.delete("BUNDLED_ACTIONS_DIR");
+    ac.abort();
+    await server.finished;
+    await Deno.remove(bundled, { recursive: true });
+  }
+});

--- a/src/policy_engine/ts/src/config.ts
+++ b/src/policy_engine/ts/src/config.ts
@@ -1,0 +1,36 @@
+// Sandbox configuration for the policy engine.
+//
+// The engine never shells out to the `deno` binary to evaluate expressions —
+// instead it runs them in an in-process Web Worker with restricted Deno
+// permissions (see src/eval.ts). This module resolves how that sandbox is
+// configured, from CLI flags and/or environment variables.
+
+/**
+ * SandboxConfig controls how untrusted workflow content is executed.
+ *
+ * - `netOnly`: when true, the engine runs in a strict network-only sandbox.
+ *   Expression evaluation is granted `net` permission (and nothing else),
+ *   and any step that would require the filesystem or process execution
+ *   (`run` steps, `uses` actions) is refused. When false (the default), the
+ *   expression sandbox is granted no permissions at all, while `run`/`uses`
+ *   steps execute normally.
+ */
+export interface SandboxConfig {
+  netOnly: boolean;
+}
+
+/** Interpret common truthy strings ("1", "true", "yes", "on") as true. */
+export function envBool(name: string): boolean {
+  const v = (Deno.env.get(name) ?? "").trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+/**
+ * Resolve the sandbox configuration. An explicit flag value (from the CLI)
+ * takes precedence; otherwise the POLICY_ENGINE_NET_ONLY environment variable
+ * is consulted. Defaults to the unrestricted ("full") sandbox.
+ */
+export function resolveSandboxConfig(flag?: boolean): SandboxConfig {
+  const netOnly = flag !== undefined ? flag : envBool("POLICY_ENGINE_NET_ONLY");
+  return { netOnly };
+}

--- a/src/policy_engine/ts/src/config.ts
+++ b/src/policy_engine/ts/src/config.ts
@@ -17,6 +17,9 @@
  */
 export interface SandboxConfig {
   netOnly: boolean;
+  /** When true, start an in-process HTTP filesystem API server and inject its
+   *  URL as POLICY_ENGINE_FS_API_URL into every action worker. */
+  fsApi?: boolean;
 }
 
 /** Interpret common truthy strings ("1", "true", "yes", "on") as true. */
@@ -30,7 +33,14 @@ export function envBool(name: string): boolean {
  * takes precedence; otherwise the POLICY_ENGINE_NET_ONLY environment variable
  * is consulted. Defaults to the unrestricted ("full") sandbox.
  */
-export function resolveSandboxConfig(flag?: boolean): SandboxConfig {
-  const netOnly = flag !== undefined ? flag : envBool("POLICY_ENGINE_NET_ONLY");
-  return { netOnly };
+export function resolveSandboxConfig(
+  flags?: { netOnly?: boolean; fsApi?: boolean },
+): SandboxConfig {
+  const netOnly = flags?.netOnly !== undefined
+    ? flags.netOnly
+    : envBool("POLICY_ENGINE_NET_ONLY");
+  const fsApi = flags?.fsApi !== undefined
+    ? flags.fsApi
+    : envBool("POLICY_ENGINE_FS_API");
+  return { netOnly, fsApi };
 }

--- a/src/policy_engine/ts/src/eval.ts
+++ b/src/policy_engine/ts/src/eval.ts
@@ -1,0 +1,140 @@
+// Native, sandboxed JavaScript expression evaluator.
+//
+// GitHub Actions ${{ }} expressions are evaluated as JavaScript. Rather than
+// shelling out to a `deno run` subprocess (which spawns a process and touches
+// the filesystem), this evaluator runs the expression inside an in-process Web
+// Worker whose Deno permissions are locked down. Even though the host process
+// may run with broad permissions, the worker can only do what its permission
+// set allows — by default nothing (no filesystem, no network, no subprocess),
+// or, in net-only mode, network access and nothing else.
+//
+// Requires the `--unstable-worker-options` flag so per-worker permissions can
+// be set; this is baked into the CLI shebang and the deno tasks.
+
+import { Trace } from "./logger.ts";
+
+/** Source of the worker that evaluates expressions in isolation. */
+const WORKER_SOURCE = `
+self.onmessage = (e) => {
+  const { id, code } = e.data;
+  try {
+    // Indirect eval runs in global scope; the host builds a self-contained
+    // IIFE in \`code\` that defines its own contexts and returns a value.
+    const result = (0, eval)(code);
+    self.postMessage({ id, ok: true, result: result === undefined ? "undefined" : String(result) });
+  } catch (err) {
+    self.postMessage({ id, ok: false, error: String(err && err.message ? err.message : err) });
+  }
+};
+`;
+
+interface Pending {
+  resolve: (result: string) => void;
+  reject: (err: Error) => void;
+}
+
+export interface EvalResult {
+  ok: boolean;
+  result: string;
+}
+
+/**
+ * Evaluates JavaScript expressions in a permission-restricted Web Worker.
+ * A single worker is created lazily and reused for all evaluations; call
+ * close() to terminate it.
+ */
+export class ExpressionEvaluator {
+  private allowNet: boolean;
+  private worker: Worker | null = null;
+  private blobUrl: string | null = null;
+  private nextId = 1;
+  private pending = new Map<number, Pending>();
+
+  constructor(opts: { allowNet?: boolean } = {}) {
+    this.allowNet = opts.allowNet ?? false;
+  }
+
+  /** Permissions granted to the worker: never read/write/run; net is opt-in. */
+  private permissions(): Deno.PermissionOptionsObject {
+    return {
+      net: this.allowNet ? true : false,
+      read: false,
+      write: false,
+      run: false,
+      env: false,
+      sys: false,
+      ffi: false,
+      import: false,
+    };
+  }
+
+  private ensureWorker(): Worker {
+    if (this.worker) return this.worker;
+
+    this.blobUrl = URL.createObjectURL(
+      new Blob([WORKER_SOURCE], { type: "text/javascript" }),
+    );
+    const worker = new Worker(this.blobUrl, {
+      type: "module",
+      deno: { permissions: this.permissions() },
+    });
+
+    worker.onmessage = (e: MessageEvent) => {
+      const { id, ok, result, error } = e.data as {
+        id: number;
+        ok: boolean;
+        result?: string;
+        error?: string;
+      };
+      const p = this.pending.get(id);
+      if (!p) return;
+      this.pending.delete(id);
+      if (ok) p.resolve(result ?? "");
+      else p.reject(new Error(error ?? "evaluation failed"));
+    };
+
+    worker.onerror = (e: ErrorEvent) => {
+      // A worker-level error invalidates all in-flight evaluations. Reject
+      // them and drop the worker so the next call rebuilds a fresh one.
+      const err = new Error(`expression worker error: ${e.message}`);
+      for (const [, p] of this.pending) p.reject(err);
+      this.pending.clear();
+      this.disposeWorker();
+    };
+
+    this.worker = worker;
+    return worker;
+  }
+
+  /**
+   * Evaluate a self-contained JavaScript expression (an IIFE string) and
+   * return its result as a string. Rejects if the expression throws.
+   */
+  evaluate(code: string): Promise<string> {
+    Trace("ExpressionEvaluator.evaluate: %s", code);
+    const worker = this.ensureWorker();
+    const id = this.nextId++;
+    return new Promise<string>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      worker.postMessage({ id, code });
+    });
+  }
+
+  private disposeWorker(): void {
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+    if (this.blobUrl) {
+      URL.revokeObjectURL(this.blobUrl);
+      this.blobUrl = null;
+    }
+  }
+
+  /** Terminate the worker and reject any outstanding evaluations. */
+  close(): void {
+    for (const [, p] of this.pending) p.reject(new Error("evaluator closed"));
+    this.pending.clear();
+    this.disposeWorker();
+  }
+}

--- a/src/policy_engine/ts/src/eval_test.ts
+++ b/src/policy_engine/ts/src/eval_test.ts
@@ -1,0 +1,102 @@
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { ExpressionEvaluator } from "./eval.ts";
+import { WorkflowExecutor } from "./workflow.ts";
+
+Deno.test("ExpressionEvaluator: evaluates a pure expression in the worker", async () => {
+  const ev = new ExpressionEvaluator();
+  try {
+    assertEquals(await ev.evaluate(`(() => 1 + 2)()`), "3");
+    assertEquals(await ev.evaluate(`(() => "a" === "a")()`), "true");
+    assertEquals(await ev.evaluate(`(() => { const x = {a:{b:5}}; return x.a.b; })()`), "5");
+  } finally {
+    ev.close();
+  }
+});
+
+Deno.test("ExpressionEvaluator: reuses one worker across many evaluations", async () => {
+  const ev = new ExpressionEvaluator();
+  try {
+    const results = await Promise.all(
+      [...Array(20)].map((_, i) => ev.evaluate(`(() => ${i} * 2)()`)),
+    );
+    assertEquals(results, [...Array(20)].map((_, i) => String(i * 2)));
+  } finally {
+    ev.close();
+  }
+});
+
+Deno.test("ExpressionEvaluator: sandbox blocks filesystem access (default, no perms)", async () => {
+  const ev = new ExpressionEvaluator();
+  try {
+    await assertRejects(
+      () => ev.evaluate(`(() => Deno.readTextFileSync("/etc/hostname"))()`),
+      Error,
+    );
+  } finally {
+    ev.close();
+  }
+});
+
+Deno.test("ExpressionEvaluator: net-only sandbox still blocks filesystem and exec", async () => {
+  const ev = new ExpressionEvaluator({ allowNet: true });
+  try {
+    await assertRejects(
+      () => ev.evaluate(`(() => Deno.readTextFileSync("/etc/hostname"))()`),
+      Error,
+    );
+    await assertRejects(
+      () => ev.evaluate(`(() => new Deno.Command("echo", { args: ["hi"] }).outputSync())()`),
+      Error,
+    );
+  } finally {
+    ev.close();
+  }
+});
+
+Deno.test("WorkflowExecutor: evaluates expressions natively (no subprocess)", async () => {
+  const executor = new WorkflowExecutor();
+  const status = await executor.executeWorkflow({
+    workflow: `name: t
+on: push
+jobs:
+  j:
+    runs-on: self-hosted
+    steps:
+    - if: ${"${{ 1 == 1 }}"}
+      run: 'true'`,
+  });
+  assertEquals((status.detail as { exit_status: string }).exit_status, "success");
+});
+
+Deno.test("WorkflowExecutor: net-only mode refuses run steps (no exec, no FS)", async () => {
+  const executor = new WorkflowExecutor({ sandbox: { netOnly: true } });
+  const status = await executor.executeWorkflow({
+    workflow: `name: t
+on: push
+jobs:
+  j:
+    runs-on: self-hosted
+    steps:
+    - run: echo hi`,
+  });
+  const detail = status.detail as { exit_status: string; annotations: { error?: string[] } };
+  assertEquals(detail.exit_status, "failure");
+  assertStringIncludes(detail.annotations.error?.[0] ?? "", "net-only sandbox mode");
+});
+
+Deno.test("WorkflowExecutor: net-only mode still evaluates expressions", async () => {
+  const executor = new WorkflowExecutor({ sandbox: { netOnly: true } });
+  // The run step is skipped by a false if-condition, so no exec is attempted;
+  // the expression itself is evaluated in the (net-only) sandbox worker.
+  const status = await executor.executeWorkflow({
+    workflow: `name: t
+on: push
+jobs:
+  j:
+    runs-on: self-hosted
+    steps:
+    - if: ${"${{ 1 == 2 }}"}
+      run: echo nope`,
+  });
+  assertEquals((status.detail as { exit_status: string }).exit_status, "success");
+});

--- a/src/policy_engine/ts/src/fs_api.ts
+++ b/src/policy_engine/ts/src/fs_api.ts
@@ -1,0 +1,107 @@
+// Optional in-process HTTP filesystem API server.
+//
+// When enabled (--fs-api / POLICY_ENGINE_FS_API=1), the engine binds a Hono
+// server on a random local port and exposes simple file-system primitives over
+// HTTP.  The bound URL is injected as POLICY_ENGINE_FS_API_URL into every
+// action worker's environment so that net-only actions (which cannot touch the
+// real FS directly) can delegate writes/reads to the host via fetch().
+//
+// All paths are resolved relative to the supplied root directory and are
+// validated to stay within it — traversal attacks are rejected with 403.
+
+import { Hono } from "hono";
+import { join, normalize, resolve } from "@std/path";
+
+function safeJoin(root: string, rel: string): string | null {
+  const full = normalize(resolve(root, rel.replace(/^\/+/, "")));
+  return full.startsWith(root) ? full : null;
+}
+
+export interface FsApiServer {
+  url: string;
+  close(): Promise<void>;
+}
+
+export async function startFsApiServer(root: string): Promise<FsApiServer> {
+  const app = new Hono();
+
+  // GET /file?path=<rel>  → file bytes
+  app.get("/file", async (c) => {
+    const rel = c.req.query("path") ?? "";
+    const full = safeJoin(root, rel);
+    if (!full) return c.text("forbidden", 403);
+    try {
+      const bytes = await Deno.readFile(full);
+      return new Response(bytes, {
+        headers: { "content-type": "application/octet-stream" },
+      });
+    } catch (e) {
+      if (e instanceof Deno.errors.NotFound) return c.text("not found", 404);
+      return c.text(String(e), 500);
+    }
+  });
+
+  // PUT /file?path=<rel>  body → write file (creates parents)
+  app.put("/file", async (c) => {
+    const rel = c.req.query("path") ?? "";
+    const full = safeJoin(root, rel);
+    if (!full) return c.text("forbidden", 403);
+    const parent = full.substring(0, full.lastIndexOf("/"));
+    if (parent) await Deno.mkdir(parent, { recursive: true });
+    const body = new Uint8Array(await c.req.arrayBuffer());
+    await Deno.writeFile(full, body);
+    return c.text("ok");
+  });
+
+  // POST /mkdir?path=<rel>  → create directory (recursive)
+  app.post("/mkdir", async (c) => {
+    const rel = c.req.query("path") ?? "";
+    const full = safeJoin(root, rel);
+    if (!full) return c.text("forbidden", 403);
+    await Deno.mkdir(full, { recursive: true });
+    return c.text("ok");
+  });
+
+  // GET /ls?path=<rel>  → JSON array of entry names with type
+  app.get("/ls", async (c) => {
+    const rel = c.req.query("path") ?? "";
+    const full = safeJoin(root, rel || ".");
+    if (!full) return c.text("forbidden", 403);
+    try {
+      const entries: { name: string; type: "file" | "dir" }[] = [];
+      for await (const entry of Deno.readDir(full)) {
+        entries.push({ name: entry.name, type: entry.isDirectory ? "dir" : "file" });
+      }
+      return c.json(entries);
+    } catch (e) {
+      if (e instanceof Deno.errors.NotFound) return c.text("not found", 404);
+      return c.text(String(e), 500);
+    }
+  });
+
+  // Bind to a random local port.
+  const ac = new AbortController();
+  let resolveReady!: (port: number) => void;
+  const readyPromise = new Promise<number>((r) => (resolveReady = r));
+
+  const server = Deno.serve(
+    {
+      port: 0,
+      hostname: "127.0.0.1",
+      signal: ac.signal,
+      onListen: ({ port }) => resolveReady(port),
+    },
+    app.fetch,
+  );
+
+  const port = await readyPromise;
+  const url = `http://127.0.0.1:${port}`;
+
+  return {
+    url,
+    close: async () => {
+      ac.abort();
+      await server.finished;
+    },
+  };
+}

--- a/src/policy_engine/ts/src/fs_api_test.ts
+++ b/src/policy_engine/ts/src/fs_api_test.ts
@@ -1,0 +1,96 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { startFsApiServer } from "./fs_api.ts";
+
+Deno.test("FsApiServer: mkdir, write, read, ls", async () => {
+  const root = await Deno.makeTempDir({ prefix: "pe-fsapi-test-" });
+  const srv = await startFsApiServer(root);
+
+  try {
+    // mkdir
+    let r = await fetch(`${srv.url}/mkdir?path=sub/dir`, { method: "POST" });
+    assertEquals(r.status, 200);
+
+    // write file (PUT)
+    const content = new TextEncoder().encode("hello world");
+    r = await fetch(`${srv.url}/file?path=sub/dir/hello.txt`, {
+      method: "PUT",
+      body: content,
+    });
+    assertEquals(r.status, 200);
+
+    // verify on real FS
+    const onDisk = await Deno.readTextFile(join(root, "sub/dir/hello.txt"));
+    assertEquals(onDisk, "hello world");
+
+    // read file (GET)
+    r = await fetch(`${srv.url}/file?path=sub/dir/hello.txt`);
+    assertEquals(r.status, 200);
+    const bytes = new Uint8Array(await r.arrayBuffer());
+    assertEquals(new TextDecoder().decode(bytes), "hello world");
+
+    // ls
+    r = await fetch(`${srv.url}/ls?path=sub/dir`);
+    assertEquals(r.status, 200);
+    const entries = await r.json() as { name: string; type: string }[];
+    assertEquals(entries.length, 1);
+    assertEquals(entries[0].name, "hello.txt");
+    assertEquals(entries[0].type, "file");
+
+    // path traversal is blocked
+    r = await fetch(`${srv.url}/file?path=../escape`);
+    assertEquals(r.status, 403);
+  } finally {
+    await srv.close();
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("WorkflowExecutor: fs-api injects POLICY_ENGINE_FS_API_URL", async () => {
+  const { WorkflowExecutor } = await import("./workflow.ts");
+
+  // A bundled net-only action that reads the URL from its env and hits the FS API.
+  const bundled = await Deno.makeTempDir({ prefix: "pe-bundled-fsapi-" });
+  const actDir = join(bundled, "test", "fsact");
+  await Deno.mkdir(actDir, { recursive: true });
+  await Deno.writeTextFile(
+    join(actDir, "action.yml"),
+    `name: Test\ndescription: t\nruns:\n  using: node20\n  main: index.ts\n`,
+  );
+  await Deno.writeTextFile(
+    join(actDir, "index.ts"),
+    `const fsUrl = (Deno.env.get("POLICY_ENGINE_FS_API_URL") ?? "").replace(/\\/+$/, "");
+if (!fsUrl) { console.error("no FS API URL"); Deno.exit(1); }
+// Write a file via the API.
+const body = new TextEncoder().encode("from-action");
+const r = await fetch(fsUrl + "/file?path=result.txt", { method: "PUT", body });
+if (!r.ok) { console.error("write failed: " + r.status); Deno.exit(1); }
+// Read it back.
+const r2 = await fetch(fsUrl + "/file?path=result.txt");
+const text = new TextDecoder().decode(new Uint8Array(await r2.arrayBuffer()));
+console.log("read-back: " + text);
+const out = Deno.env.get("GITHUB_OUTPUT");
+if (out) await Deno.writeTextFile(out, "content=" + text + "\\n", { append: true });
+`,
+  );
+
+  Deno.env.set("BUNDLED_ACTIONS_DIR", bundled);
+  try {
+    const executor = new WorkflowExecutor({ sandbox: { netOnly: true, fsApi: true } });
+    const status = await executor.executeWorkflow({
+      workflow: `name: t
+on: push
+jobs:
+  j:
+    runs-on: self-hosted
+    steps:
+    - id: a
+      uses: test/fsact@v1`,
+    });
+    assertEquals((status.detail as { exit_status: string }).exit_status, "success");
+    assertStringIncludes(status.console_output ?? "", "read-back: from-action");
+  } finally {
+    Deno.env.delete("BUNDLED_ACTIONS_DIR");
+    await Deno.remove(bundled, { recursive: true });
+  }
+});

--- a/src/policy_engine/ts/src/logger.ts
+++ b/src/policy_engine/ts/src/logger.ts
@@ -1,0 +1,52 @@
+// Leveled logging, a port of ../../common/logger.go. Controlled by the
+// POLICY_ENGINE_LOG_LEVEL env var: trace, debug, info (default), warn, error.
+
+export enum LogLevel {
+  Trace = 0,
+  Debug = 1,
+  Info = 2,
+  Warn = 3,
+  Error = 4,
+}
+
+function currentLevel(): LogLevel {
+  const v = (Deno.env.get("POLICY_ENGINE_LOG_LEVEL") ?? "info").toLowerCase();
+  switch (v) {
+    case "trace":
+      return LogLevel.Trace;
+    case "debug":
+      return LogLevel.Debug;
+    case "warn":
+      return LogLevel.Warn;
+    case "error":
+      return LogLevel.Error;
+    default:
+      return LogLevel.Info;
+  }
+}
+
+function log(level: LogLevel, tag: string, msg: string, args: unknown[]): void {
+  if (level < currentLevel()) return;
+  const formatted = args.length > 0 ? sprintf(msg, args) : msg;
+  console.error(`[${tag}] ${formatted}`);
+}
+
+// Minimal printf-style formatter supporting %s, %d, %v, %q, %w.
+function sprintf(fmt: string, args: unknown[]): string {
+  let i = 0;
+  return fmt.replace(/%[sdvqw%]/g, (m) => {
+    if (m === "%%") return "%";
+    const a = args[i++];
+    if (m === "%q") return JSON.stringify(String(a));
+    if (a instanceof Error) return a.message;
+    if (typeof a === "object") return JSON.stringify(a);
+    return String(a);
+  });
+}
+
+export const Trace = (msg: string, ...args: unknown[]) => log(LogLevel.Trace, "TRACE", msg, args);
+export const Debug = (msg: string, ...args: unknown[]) => log(LogLevel.Debug, "DEBUG", msg, args);
+export const Info = (msg: string, ...args: unknown[]) => log(LogLevel.Info, "INFO", msg, args);
+export const Warn = (msg: string, ...args: unknown[]) => log(LogLevel.Warn, "WARN", msg, args);
+export const LogError = (msg: string, ...args: unknown[]) =>
+  log(LogLevel.Error, "ERROR", msg, args);

--- a/src/policy_engine/ts/src/models.ts
+++ b/src/policy_engine/ts/src/models.ts
@@ -1,0 +1,232 @@
+// Models for the policy engine — a TypeScript (Deno) port of the Go
+// implementation in ../../common/models.go. Implements GitHub Actions workflow
+// evaluation as a policy engine.
+
+/** Exit status of a completed policy engine request. */
+export type PolicyEngineCompleteExitStatus = "success" | "failure";
+
+export const ExitStatusSuccess: PolicyEngineCompleteExitStatus = "success";
+export const ExitStatusFailure: PolicyEngineCompleteExitStatus = "failure";
+
+/** Status of a policy engine request. */
+export type PolicyEngineStatuses =
+  | "submitted"
+  | "in_progress"
+  | "complete"
+  | "unknown"
+  | "input_validation_error";
+
+export const StatusSubmitted: PolicyEngineStatuses = "submitted";
+export const StatusInProgress: PolicyEngineStatuses = "in_progress";
+export const StatusComplete: PolicyEngineStatuses = "complete";
+export const StatusUnknown: PolicyEngineStatuses = "unknown";
+export const StatusInputValidationError: PolicyEngineStatuses = "input_validation_error";
+
+/** A completed policy engine request. */
+export interface PolicyEngineComplete {
+  id: string;
+  exit_status: PolicyEngineCompleteExitStatus;
+  outputs?: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
+}
+
+/** A submitted policy engine request. */
+export interface PolicyEngineSubmitted {
+  id: string;
+}
+
+/** An in-progress policy engine request. */
+export interface PolicyEngineInProgress {
+  id: string;
+  status_updates?: Record<string, PolicyEngineStatusUpdateJob>;
+}
+
+/** An unknown policy engine request. */
+export interface PolicyEngineUnknown {
+  id: string;
+}
+
+/** A step status update. */
+export interface PolicyEngineStatusUpdateJobStep {
+  status: PolicyEngineStatuses;
+  metadata?: Record<string, string>;
+  outputs?: Record<string, unknown>;
+}
+
+/** A job status update. */
+export interface PolicyEngineStatusUpdateJob {
+  steps?: Record<string, PolicyEngineStatusUpdateJobStep>;
+}
+
+/** An input validation error. */
+export interface PolicyEngineInputValidationError {
+  msg: string;
+  loc: string[];
+  type: string;
+  url?: string;
+  input?: string;
+}
+
+/** The full status response. */
+export interface PolicyEngineStatus {
+  status: PolicyEngineStatuses;
+  detail: unknown;
+  console_output?: string;
+}
+
+/** A step in a workflow job. */
+export interface PolicyEngineWorkflowJobStep {
+  id?: string;
+  if?: unknown;
+  name?: string;
+  uses?: string;
+  shell?: string;
+  with?: Record<string, unknown>;
+  env?: Record<string, unknown>;
+  run?: string;
+}
+
+/** A job in a workflow. */
+export interface PolicyEngineWorkflowJob {
+  "runs-on"?: unknown;
+  steps?: PolicyEngineWorkflowJobStep[];
+}
+
+/** A workflow definition. */
+export interface PolicyEngineWorkflow {
+  name?: string;
+  on?: unknown;
+  jobs?: Record<string, PolicyEngineWorkflowJob>;
+}
+
+/** A request to the policy engine. */
+export interface PolicyEngineRequest {
+  inputs?: Record<string, unknown>;
+  workflow?: unknown;
+  context?: Record<string, unknown>;
+  stack?: Record<string, unknown>;
+}
+
+/** Validate a PolicyEngineRequest. Throws on invalid input. */
+export function validateRequest(r: PolicyEngineRequest): void {
+  if (r.workflow === undefined || r.workflow === null) {
+    throw new Error("workflow is required");
+  }
+}
+
+/** Sender of a GitHub webhook event. */
+export interface GitHubWebhookEventSender {
+  login: string;
+  webhook_workflow?: string;
+}
+
+/** Repository in a GitHub webhook event. */
+export interface GitHubWebhookEventRepository {
+  full_name: string;
+}
+
+/** A GitHub webhook event. */
+export interface GitHubWebhookEvent {
+  after?: string;
+  sender?: GitHubWebhookEventSender;
+  repository?: GitHubWebhookEventRepository;
+}
+
+/** An annotation in a GitHub check suite. */
+export interface GitHubCheckSuiteAnnotation {
+  path?: string;
+  annotation_level?: string;
+  title?: string;
+  message?: string;
+  raw_details?: string;
+  start_line?: number;
+  end_line?: number;
+}
+
+export type TaskState = "PENDING" | "SUCCESS" | "FAILURE";
+
+/**
+ * An async task for workflow execution. Console output is buffered and
+ * broadcast to subscribers (used by the SSE stream endpoint).
+ */
+export class Task {
+  id: string;
+  status: TaskState = "PENDING";
+  result = "";
+  error: Error | null = null;
+  createdAt: Date;
+  updatedAt: Date;
+  consoleOutput: string[] = [];
+  private subscribers = new Set<(line: string) => void>();
+
+  constructor(id: string) {
+    this.id = id;
+    this.createdAt = new Date();
+    this.updatedAt = new Date();
+  }
+
+  /** Append a line of console output and notify subscribers. */
+  appendConsoleOutput(line: string): void {
+    this.consoleOutput.push(line);
+    for (const sub of this.subscribers) {
+      try {
+        sub(line);
+      } catch {
+        // Skip failed subscribers
+      }
+    }
+  }
+
+  /** All console output collected so far, joined by newlines. */
+  getConsoleOutput(): string {
+    return this.consoleOutput.join("\n");
+  }
+
+  /** Register a subscriber for new console output lines. */
+  subscribe(fn: (line: string) => void): () => void {
+    this.subscribers.add(fn);
+    return () => this.subscribers.delete(fn);
+  }
+}
+
+/** Manages async tasks. */
+export class TaskManager {
+  private tasks = new Map<string, Task>();
+
+  createTask(id: string): Task {
+    const task = new Task(id);
+    this.tasks.set(id, task);
+    return task;
+  }
+
+  getTask(id: string): Task | undefined {
+    return this.tasks.get(id);
+  }
+
+  updateTask(id: string, status: TaskState, result: string, error: Error | null): void {
+    const task = this.tasks.get(id);
+    if (task) {
+      task.status = status;
+      task.result = result;
+      task.error = error;
+      task.updatedAt = new Date();
+    }
+  }
+}
+
+/** Holds the context for executing a workflow. */
+export class WorkflowExecutionContext {
+  inputs: Record<string, unknown> = {};
+  env: Record<string, unknown> = {};
+  secrets: Record<string, string> = {};
+  outputs: Record<string, Record<string, unknown>> = {};
+  annotations: Record<string, GitHubCheckSuiteAnnotation[]> = {};
+  workspace = "";
+  tempDir = "";
+  cacheDir = "";
+  toolCacheDir = ""; // RUNNER_TOOL_CACHE
+  homeDir = ""; // Ephemeral HOME
+  shell = "bash -xe";
+  error: Error | null = null;
+  consoleOutput: string[] = [];
+}

--- a/src/policy_engine/ts/src/server.ts
+++ b/src/policy_engine/ts/src/server.ts
@@ -41,11 +41,14 @@ export function createApp(): { app: Hono; taskManager: TaskManager } {
   const taskManager = new TaskManager();
   const app = new Hono();
 
-  app.use("*", cors({
-    origin: "*",
-    allowMethods: ["GET", "POST", "OPTIONS"],
-    allowHeaders: ["Content-Type", "Authorization"],
-  }));
+  app.use(
+    "*",
+    cors({
+      origin: "*",
+      allowMethods: ["GET", "POST", "OPTIONS"],
+      allowHeaders: ["Content-Type", "Authorization"],
+    }),
+  );
 
   // Request logging.
   app.use("*", async (c, next) => {

--- a/src/policy_engine/ts/src/server.ts
+++ b/src/policy_engine/ts/src/server.ts
@@ -1,0 +1,293 @@
+// Hono-based HTTP server for the policy engine — a TypeScript (Deno) port of
+// ../../common/server.go. Exposes the request lifecycle, console output (plain
+// and SSE), the GitHub webhook receiver, and health/rate-limit endpoints.
+
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { streamSSE } from "hono/streaming";
+import {
+  type GitHubWebhookEvent,
+  type PolicyEngineComplete,
+  type PolicyEngineRequest,
+  type PolicyEngineStatus,
+  StatusComplete,
+  StatusInProgress,
+  StatusInputValidationError,
+  StatusSubmitted,
+  StatusUnknown,
+  type Task,
+  TaskManager,
+  validateRequest,
+} from "./models.ts";
+import { WorkflowExecutor } from "./workflow.ts";
+import { Debug, Info, LogError } from "./logger.ts";
+
+const DEFAULT_WEBHOOK_WORKFLOW = `
+name: 'Webhook Workflow'
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  default:
+    runs-on: self-hosted
+    steps:
+    - run: echo "Webhook received"
+`;
+
+/** Build the Hono app and its backing task manager. */
+export function createApp(): { app: Hono; taskManager: TaskManager } {
+  const taskManager = new TaskManager();
+  const app = new Hono();
+
+  app.use("*", cors({
+    origin: "*",
+    allowMethods: ["GET", "POST", "OPTIONS"],
+    allowHeaders: ["Content-Type", "Authorization"],
+  }));
+
+  // Request logging.
+  app.use("*", async (c, next) => {
+    const start = Date.now();
+    Debug("request: %s %s", c.req.method, c.req.path);
+    await next();
+    Debug("response: %s %s completed in %dms", c.req.method, c.req.path, Date.now() - start);
+  });
+
+  app.get("/health", (c) => c.json({ status: "ok" }));
+
+  app.get("/rate_limit", (c) =>
+    c.json({
+      resources: {
+        core: {
+          limit: 5000,
+          remaining: 4999,
+          reset: Math.floor(Date.now() / 1000) + 3600,
+        },
+      },
+    }));
+
+  app.post("/request/create", async (c) => {
+    let request: PolicyEngineRequest;
+    try {
+      request = await c.req.json();
+    } catch (err) {
+      return validationError(c, "Failed to parse request JSON", err as Error);
+    }
+    try {
+      validateRequest(request);
+    } catch (err) {
+      return validationError(c, "Invalid request", err as Error);
+    }
+
+    const taskID = crypto.randomUUID();
+    const task = taskManager.createTask(taskID);
+    Info("task created: id=%s", taskID);
+
+    executeWorkflowTask(taskManager, task, request); // fire and forget
+
+    const response: PolicyEngineStatus = {
+      status: StatusSubmitted,
+      detail: { id: taskID },
+    };
+    return c.json(response);
+  });
+
+  app.get("/request/status/:id", (c) => {
+    const requestID = c.req.param("id");
+    const task = taskManager.getTask(requestID);
+    if (!task) {
+      return c.json({ status: StatusUnknown, detail: { id: requestID } });
+    }
+
+    let response: PolicyEngineStatus;
+    switch (task.status) {
+      case "PENDING":
+        response = {
+          status: StatusInProgress,
+          detail: { id: requestID, status_updates: {} },
+        };
+        break;
+      case "SUCCESS":
+      case "FAILURE": {
+        try {
+          response = JSON.parse(task.result) as PolicyEngineStatus;
+          if (response.detail && typeof response.detail === "object") {
+            (response.detail as Record<string, unknown>)["id"] = requestID;
+          }
+        } catch {
+          response = {
+            status: StatusComplete,
+            detail: {
+              id: requestID,
+              exit_status: task.status === "FAILURE" ? "failure" : "success",
+            },
+          };
+        }
+        break;
+      }
+      default:
+        response = { status: StatusUnknown, detail: { id: requestID } };
+    }
+    return c.json(response);
+  });
+
+  app.get("/request/console_output/:id", (c) => {
+    const requestID = c.req.param("id");
+    const task = taskManager.getTask(requestID);
+    if (!task) return c.text("Task not found", 404);
+
+    if (task.status === "SUCCESS" || task.status === "FAILURE") {
+      try {
+        const result = JSON.parse(task.result) as PolicyEngineStatus;
+        return c.text(result.console_output ?? "");
+      } catch {
+        return c.text(task.getConsoleOutput());
+      }
+    }
+    return c.text(task.getConsoleOutput());
+  });
+
+  app.get("/request/console_output_stream/:id", (c) => {
+    const requestID = c.req.param("id");
+    const task = taskManager.getTask(requestID);
+    if (!task) return c.text("Task not found", 404);
+
+    return streamSSE(c, async (stream) => {
+      // Send everything buffered so far.
+      for (const line of [...task.consoleOutput]) {
+        await stream.writeSSE({ data: line });
+      }
+      if (isDone(task)) {
+        await stream.writeSSE({ event: "done", data: task.status });
+        return;
+      }
+
+      // Subscribe to new lines.
+      const queue: string[] = [];
+      let notify: (() => void) | null = null;
+      const unsubscribe = task.subscribe((line) => {
+        queue.push(line);
+        notify?.();
+      });
+
+      try {
+        while (true) {
+          while (queue.length > 0) {
+            await stream.writeSSE({ data: queue.shift()! });
+          }
+          if (isDone(task)) {
+            await stream.writeSSE({ event: "done", data: task.status });
+            return;
+          }
+          // Wait for a new line or a 1s keepalive tick.
+          await new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, 1000);
+            notify = () => {
+              clearTimeout(timer);
+              resolve();
+            };
+          });
+          notify = null;
+          if (queue.length === 0) {
+            await stream.writeSSE({ data: "", event: "keepalive" });
+          }
+        }
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+
+  app.post("/webhook/github", async (c) => {
+    const eventType = c.req.header("X-GitHub-Event");
+    const deliveryID = c.req.header("X-GitHub-Delivery");
+
+    if (eventType !== "push" && eventType !== "pull_request") {
+      return c.json({ message: "Event type not supported" });
+    }
+
+    let event: GitHubWebhookEvent;
+    try {
+      event = await c.req.json();
+    } catch (err) {
+      return validationError(c, "Failed to parse webhook event", err as Error);
+    }
+
+    const workflow = event.sender?.webhook_workflow || DEFAULT_WEBHOOK_WORKFLOW;
+    const request: PolicyEngineRequest = {
+      context: {
+        config: {
+          env: {
+            GITHUB_ACTOR: event.sender?.login ?? "",
+            GITHUB_REPOSITORY: event.repository?.full_name ?? "",
+          },
+        },
+      },
+      workflow,
+    };
+
+    const taskID = deliveryID || crypto.randomUUID();
+    const task = taskManager.createTask(taskID);
+    Info("webhook task created: id=%s", taskID);
+
+    executeWorkflowTask(taskManager, task, request);
+
+    return c.json({ status: StatusSubmitted, detail: { id: taskID } });
+  });
+
+  return { app, taskManager };
+}
+
+/** Execute a workflow as an async task, recording the result on the task. */
+async function executeWorkflowTask(
+  taskManager: TaskManager,
+  task: Task,
+  request: PolicyEngineRequest,
+): Promise<void> {
+  Debug("executing workflow task: id=%s", task.id);
+  const executor = new WorkflowExecutor();
+  executor.task = task;
+  try {
+    const status = await executor.executeWorkflow(request);
+    const resultJSON = JSON.stringify(status);
+    let taskStatus: "SUCCESS" | "FAILURE" = "SUCCESS";
+    const detail = status.detail as PolicyEngineComplete | undefined;
+    if (detail?.exit_status === "failure") taskStatus = "FAILURE";
+    Info("task %s completed: status=%s", task.id, taskStatus);
+    taskManager.updateTask(task.id, taskStatus, resultJSON, null);
+  } catch (err) {
+    LogError("task %s failed: %v", task.id, err);
+    taskManager.updateTask(task.id, "FAILURE", "", err as Error);
+  }
+}
+
+// deno-lint-ignore no-explicit-any
+function validationError(c: any, msg: string, err: Error) {
+  const response: PolicyEngineStatus = {
+    status: StatusInputValidationError,
+    detail: [{ msg: `${msg}: ${err.message}`, loc: ["body"], type: "value_error" }],
+  };
+  return c.json(response, 400);
+}
+
+/** True once a task has reached a terminal state. */
+function isDone(task: Task): boolean {
+  const s: string = task.status;
+  return s === "SUCCESS" || s === "FAILURE";
+}
+
+/** Parse a bind address into Deno.serve options (TCP host:port or unix path). */
+export function parseBind(bind: string): Deno.ServeTcpOptions | Deno.ServeUnixOptions {
+  if (bind.startsWith("unix:")) {
+    return { path: bind.slice("unix:".length), transport: "unix" };
+  }
+  const idx = bind.lastIndexOf(":");
+  if (idx >= 0) {
+    const hostname = bind.slice(0, idx) || "127.0.0.1";
+    const port = Number(bind.slice(idx + 1));
+    return { hostname, port };
+  }
+  return { hostname: "127.0.0.1", port: 8080 };
+}

--- a/src/policy_engine/ts/src/server.ts
+++ b/src/policy_engine/ts/src/server.ts
@@ -20,6 +20,7 @@ import {
   validateRequest,
 } from "./models.ts";
 import { WorkflowExecutor } from "./workflow.ts";
+import { resolveSandboxConfig, type SandboxConfig } from "./config.ts";
 import { Debug, Info, LogError } from "./logger.ts";
 
 const DEFAULT_WEBHOOK_WORKFLOW = `
@@ -37,7 +38,9 @@ jobs:
 `;
 
 /** Build the Hono app and its backing task manager. */
-export function createApp(): { app: Hono; taskManager: TaskManager } {
+export function createApp(
+  sandbox: SandboxConfig = resolveSandboxConfig(),
+): { app: Hono; taskManager: TaskManager } {
   const taskManager = new TaskManager();
   const app = new Hono();
 
@@ -88,7 +91,7 @@ export function createApp(): { app: Hono; taskManager: TaskManager } {
     const task = taskManager.createTask(taskID);
     Info("task created: id=%s", taskID);
 
-    executeWorkflowTask(taskManager, task, request); // fire and forget
+    executeWorkflowTask(taskManager, task, request, sandbox); // fire and forget
 
     const response: PolicyEngineStatus = {
       status: StatusSubmitted,
@@ -235,7 +238,7 @@ export function createApp(): { app: Hono; taskManager: TaskManager } {
     const task = taskManager.createTask(taskID);
     Info("webhook task created: id=%s", taskID);
 
-    executeWorkflowTask(taskManager, task, request);
+    executeWorkflowTask(taskManager, task, request, sandbox);
 
     return c.json({ status: StatusSubmitted, detail: { id: taskID } });
   });
@@ -248,9 +251,10 @@ async function executeWorkflowTask(
   taskManager: TaskManager,
   task: Task,
   request: PolicyEngineRequest,
+  sandbox: SandboxConfig,
 ): Promise<void> {
   Debug("executing workflow task: id=%s", task.id);
-  const executor = new WorkflowExecutor();
+  const executor = new WorkflowExecutor({ sandbox });
   executor.task = task;
   try {
     const status = await executor.executeWorkflow(request);

--- a/src/policy_engine/ts/src/workflow.ts
+++ b/src/policy_engine/ts/src/workflow.ts
@@ -20,6 +20,7 @@ import { Debug, Info, LogError, Trace } from "./logger.ts";
 import { ExpressionEvaluator } from "./eval.ts";
 import { runActionInWorker } from "./action_worker.ts";
 import { resolveSandboxConfig, type SandboxConfig } from "./config.ts";
+import { type FsApiServer, startFsApiServer } from "./fs_api.ts";
 
 /** Parse a workflow from a string (YAML) or an object. */
 export function parseWorkflow(input: unknown): PolicyEngineWorkflow {
@@ -53,10 +54,9 @@ export class WorkflowExecutor {
   task: Task | null = null;
   readonly sandbox: SandboxConfig;
   private evaluator: ExpressionEvaluator;
-  // Path to the deno binary, used only to run node-based `uses` actions (the
-  // action's own code) — never for evaluating ${{ }} expressions, which run
-  // in-process in the sandboxed worker. In net-only mode no action runs at all.
   private denoPath: string;
+  // Lazily started FS API server (when sandbox.fsApi is true).
+  private fsApiServer: FsApiServer | null = null;
 
   constructor(opts: { sandbox?: SandboxConfig; denoPath?: string } = {}) {
     this.ctx = new WorkflowExecutionContext();
@@ -77,6 +77,12 @@ export class WorkflowExecutor {
     await this.initializeContext(request);
     Debug("context initialized: workspace=%s", this.ctx.workspace);
 
+    if (this.sandbox.fsApi) {
+      const fsRoot = this.ctx.workspace || await Deno.makeTempDir({ prefix: "pe-fsapi-" });
+      this.fsApiServer = await startFsApiServer(fsRoot);
+      Info("FS API server started at %s (root=%s)", this.fsApiServer.url, fsRoot);
+    }
+
     try {
       for (const [jobName, job] of Object.entries(jobs)) {
         Info("starting job: %s (steps=%d)", jobName, job.steps?.length ?? 0);
@@ -92,6 +98,10 @@ export class WorkflowExecutor {
       Info("workflow completed successfully");
       return this.createSuccessStatus();
     } finally {
+      if (this.fsApiServer) {
+        await this.fsApiServer.close();
+        this.fsApiServer = null;
+      }
       // Clean up ephemeral directories. cacheDir is intentionally kept.
       await this.removeAll(this.ctx.workspace);
       await this.removeAll(this.ctx.toolCacheDir);
@@ -269,6 +279,10 @@ export class WorkflowExecutor {
     env["RUNNER_TOOL_CACHE"] = this.ctx.toolCacheDir;
     env["AGENT_TOOLSDIRECTORY"] = this.ctx.toolCacheDir;
     env["HOME"] = this.ctx.homeDir;
+
+    if (this.fsApiServer) {
+      env["POLICY_ENGINE_FS_API_URL"] = this.fsApiServer.url;
+    }
 
     return env;
   }

--- a/src/policy_engine/ts/src/workflow.ts
+++ b/src/policy_engine/ts/src/workflow.ts
@@ -548,9 +548,21 @@ console.log(result)
   ): Promise<void> {
     const runScript = this.evaluateExpression(step.run!);
 
-    const outputFile = await Deno.makeTempFile({ dir: this.ctx.tempDir, prefix: "output-", suffix: ".txt" });
-    const envFile = await Deno.makeTempFile({ dir: this.ctx.tempDir, prefix: "env-", suffix: ".txt" });
-    const pathFile = await Deno.makeTempFile({ dir: this.ctx.tempDir, prefix: "path-", suffix: ".txt" });
+    const outputFile = await Deno.makeTempFile({
+      dir: this.ctx.tempDir,
+      prefix: "output-",
+      suffix: ".txt",
+    });
+    const envFile = await Deno.makeTempFile({
+      dir: this.ctx.tempDir,
+      prefix: "env-",
+      suffix: ".txt",
+    });
+    const pathFile = await Deno.makeTempFile({
+      dir: this.ctx.tempDir,
+      prefix: "path-",
+      suffix: ".txt",
+    });
 
     env["GITHUB_OUTPUT"] = outputFile;
     env["GITHUB_ENV"] = envFile;
@@ -567,7 +579,9 @@ console.log(result)
         this.ctx.outputs[step.id]["outputs"] = outputs;
       }
 
-      for (const [k, v] of Object.entries(parseGitHubActionsOutputs(await readTextOrEmpty(envFile)))) {
+      for (
+        const [k, v] of Object.entries(parseGitHubActionsOutputs(await readTextOrEmpty(envFile)))
+      ) {
         this.ctx.env[k] = v;
       }
     } finally {

--- a/src/policy_engine/ts/src/workflow.ts
+++ b/src/policy_engine/ts/src/workflow.ts
@@ -1,0 +1,855 @@
+// Workflow execution engine — a TypeScript (Deno) port of
+// ../../common/workflow.go. Executes GitHub Actions workflows: evaluates
+// ${{ }} expressions via Deno, runs `run` steps and `uses` actions
+// (node / composite / local / remote), and collects outputs and annotations.
+
+import { parse as parseYaml } from "@std/yaml";
+import { join } from "@std/path";
+import {
+  type GitHubCheckSuiteAnnotation,
+  type PolicyEngineRequest,
+  type PolicyEngineStatus,
+  type PolicyEngineWorkflow,
+  type PolicyEngineWorkflowJob,
+  type PolicyEngineWorkflowJobStep,
+  StatusComplete,
+  type Task,
+  WorkflowExecutionContext,
+} from "./models.ts";
+import { Debug, Info, LogError, Trace } from "./logger.ts";
+
+/** Parse a workflow from a string (YAML) or an object. */
+export function parseWorkflow(input: unknown): PolicyEngineWorkflow {
+  if (typeof input === "string") {
+    return parseYaml(input) as PolicyEngineWorkflow;
+  }
+  if (input && typeof input === "object") {
+    return input as PolicyEngineWorkflow;
+  }
+  throw new Error(`unsupported workflow type: ${typeof input}`);
+}
+
+interface ActionStep {
+  run?: string;
+  shell?: string;
+  env?: Record<string, string>;
+}
+
+interface ActionDef {
+  runs?: {
+    using?: string;
+    main?: string;
+    steps?: ActionStep[];
+  };
+  inputs?: Record<string, { default?: string }>;
+}
+
+/** Executes workflows. */
+export class WorkflowExecutor {
+  denoPath: string;
+  ctx: WorkflowExecutionContext;
+  task: Task | null = null;
+
+  constructor(denoPath = Deno.execPath()) {
+    this.denoPath = denoPath;
+    this.ctx = new WorkflowExecutionContext();
+  }
+
+  /** Execute a parsed workflow and return its final status. */
+  async executeWorkflow(request: PolicyEngineRequest): Promise<PolicyEngineStatus> {
+    Info("executing workflow");
+    const workflow = parseWorkflow(request.workflow);
+    const jobs = workflow.jobs ?? {};
+    Info("workflow parsed: name=%q jobs=%d", workflow.name ?? "", Object.keys(jobs).length);
+
+    await this.initializeContext(request);
+    Debug("context initialized: workspace=%s", this.ctx.workspace);
+
+    try {
+      for (const [jobName, job] of Object.entries(jobs)) {
+        Info("starting job: %s (steps=%d)", jobName, job.steps?.length ?? 0);
+        try {
+          await this.executeJob(jobName, job);
+        } catch (err) {
+          LogError("job %s failed: %v", jobName, err);
+          this.ctx.error = err as Error;
+          return this.createErrorStatus(err as Error);
+        }
+        Info("job %s completed successfully", jobName);
+      }
+      Info("workflow completed successfully");
+      return this.createSuccessStatus();
+    } finally {
+      // Clean up ephemeral directories. cacheDir is intentionally kept.
+      await this.removeAll(this.ctx.workspace);
+      await this.removeAll(this.ctx.toolCacheDir);
+      await this.removeAll(this.ctx.homeDir);
+    }
+  }
+
+  private async removeAll(path: string): Promise<void> {
+    if (!path) return;
+    try {
+      await Deno.remove(path, { recursive: true });
+    } catch {
+      // ignore
+    }
+  }
+
+  /** Initialize the execution context from the request. */
+  private async initializeContext(request: PolicyEngineRequest): Promise<void> {
+    if (request.inputs) {
+      Object.assign(this.ctx.inputs, request.inputs);
+    }
+
+    const context = request.context;
+    if (context) {
+      const config = context["config"] as Record<string, unknown> | undefined;
+      const env = config?.["env"] as Record<string, unknown> | undefined;
+      if (env) Object.assign(this.ctx.env, env);
+
+      const secrets = context["secrets"] as Record<string, unknown> | undefined;
+      if (secrets) {
+        for (const [k, v] of Object.entries(secrets)) {
+          if (typeof v === "string") this.ctx.secrets[k] = v;
+        }
+      }
+    }
+
+    // GITHUB_TOKEN is available as both a secret and an env var in real Actions.
+    const token = this.ctx.secrets["GITHUB_TOKEN"];
+    if (token && this.ctx.env["GITHUB_TOKEN"] === undefined) {
+      this.ctx.env["GITHUB_TOKEN"] = token;
+    }
+
+    const cwd = Deno.cwd();
+    this.ctx.cacheDir = join(cwd, ".cache");
+    this.ctx.tempDir = join(cwd, ".tempdir");
+    await Deno.mkdir(this.ctx.cacheDir, { recursive: true });
+    await Deno.mkdir(this.ctx.tempDir, { recursive: true });
+
+    this.ctx.workspace = await Deno.makeTempDir({ dir: this.ctx.tempDir, prefix: "workspace-" });
+    this.ctx.toolCacheDir = await Deno.makeTempDir({ dir: this.ctx.tempDir, prefix: "toolcache-" });
+    this.ctx.homeDir = await Deno.makeTempDir({ dir: this.ctx.tempDir, prefix: "home-" });
+  }
+
+  /** Execute a single job. */
+  private async executeJob(_jobName: string, job: PolicyEngineWorkflowJob): Promise<void> {
+    const steps = job.steps ?? [];
+    for (let i = 0; i < steps.length; i++) {
+      const step = steps[i];
+      let stepName = `step_${i + 1}`;
+      if (step.id) stepName = step.id;
+      else if (step.name) stepName = step.name;
+
+      if (step.if !== undefined && step.if !== null) {
+        if (!this.evaluateCondition(step.if)) {
+          Info("step %s skipped (if condition false)", stepName);
+          continue;
+        }
+      }
+
+      Info("starting step: %s", stepName);
+      if (step.shell) this.ctx.shell = step.shell;
+
+      const stepEnv = this.buildStepEnv(step);
+
+      this.emit(`##[group]${stepName}`);
+
+      let err: Error | null = null;
+      try {
+        if (step.uses) {
+          await this.executeStepUses(step, stepEnv);
+        } else if (step.run) {
+          await this.executeStepRun(step, stepEnv);
+        }
+      } catch (e) {
+        err = e as Error;
+      }
+
+      this.emit("##[endgroup]");
+
+      if (err) {
+        LogError("step %s failed: %v", stepName, err);
+        this.emit(`##[error]step ${stepName} failed: ${err.message}`);
+        throw new Error(`step ${stepName} failed: ${err.message}`);
+      }
+      Info("step %s completed", stepName);
+    }
+  }
+
+  /** Append a marker line to both the snapshot buffer and the live task stream. */
+  private emit(line: string): void {
+    this.ctx.consoleOutput.push(line);
+    if (this.task) this.task.appendConsoleOutput(line);
+  }
+
+  /**
+   * Evaluate an `if` condition. Booleans/numbers are handled directly; string
+   * conditions without ${{ }} are wrapped before evaluation. Unresolved
+   * expressions fail closed (return false via throw), matching GitHub Actions.
+   */
+  evaluateCondition(condition: unknown): boolean {
+    if (typeof condition === "boolean") return condition;
+    if (typeof condition === "number") return condition !== 0;
+    if (typeof condition === "string") {
+      if (condition === "") return true;
+      const trimmed = condition.trim().toLowerCase();
+      if (trimmed === "true" || trimmed === "1") return true;
+      if (trimmed === "false" || trimmed === "0") return false;
+
+      let exprStr = condition;
+      if (!exprStr.includes("${{")) exprStr = "${{ " + exprStr + " }}";
+      let evaluated = this.evaluateExpression(exprStr);
+      if (evaluated.includes("${{")) {
+        throw new Error(`could not evaluate expression ${JSON.stringify(condition)}`);
+      }
+      evaluated = evaluated.trim().toLowerCase();
+      if (evaluated === "__github_actions_always__") return true;
+      if (
+        evaluated === "false" || evaluated === "0" || evaluated === "" ||
+        evaluated === "null" || evaluated === "undefined"
+      ) {
+        return false;
+      }
+      return true;
+    }
+    return true;
+  }
+
+  /** Build the environment map for a step. */
+  buildStepEnv(step: PolicyEngineWorkflowJobStep): Record<string, string> {
+    const env: Record<string, string> = {};
+
+    for (const [k, v] of Object.entries(this.ctx.env)) {
+      env[k] = String(v);
+    }
+    for (const [k, v] of Object.entries(step.env ?? {})) {
+      env[k] = this.evaluateExpression(String(v));
+    }
+    for (const [k, v] of Object.entries(step.with ?? {})) {
+      env["INPUT_" + k.toUpperCase()] = this.evaluateExpression(String(v));
+    }
+
+    env["GITHUB_WORKSPACE"] = this.ctx.workspace;
+    env["RUNNER_TEMP"] = this.ctx.tempDir;
+    env["RUNNER_TOOL_CACHE"] = this.ctx.toolCacheDir;
+    env["AGENT_TOOLSDIRECTORY"] = this.ctx.toolCacheDir;
+    env["HOME"] = this.ctx.homeDir;
+
+    return env;
+  }
+
+  /** Evaluate all ${{ ... }} occurrences in a string. */
+  evaluateExpression(expr: string): string {
+    if (!expr.includes("${{")) return expr;
+    return expr.replace(/\$\{\{\s*([\s\S]+?)\s*\}\}/g, (_m, inner: string) => {
+      return this.evaluateInnerExpression(inner.trim());
+    });
+  }
+
+  /** Evaluate a single expression (content between ${{ and }}) using Deno. */
+  private evaluateInnerExpression(inner: string): string {
+    try {
+      return this.evaluateUsingJavaScript(inner);
+    } catch {
+      // Fall back to simple property-path resolution.
+      const data: Record<string, unknown> = {
+        github: this.buildGitHubContext(),
+        steps: this.ctx.outputs,
+        inputs: this.ctx.inputs,
+        env: this.ctx.env,
+      };
+      const value = resolvePropertyPath(inner, data);
+      if (value !== undefined && value !== null) return String(value);
+      return "${{ " + inner + " }}";
+    }
+  }
+
+  /**
+   * Evaluate an expression by constructing a JS file with the github, runner,
+   * steps, and inputs contexts and running it with Deno.
+   */
+  private evaluateUsingJavaScript(codeBlock: string): string {
+    const githubCtx = this.buildGitHubContext();
+    const stepsCtx = convertBoolStrings(this.ctx.outputs);
+    const inputsCtx = this.ctx.inputs;
+    const runnerCtx = { debug: 1 };
+
+    const transformed = transformPropertyAccessors(codeBlock);
+
+    const jsCode = `function always() { return "__GITHUB_ACTIONS_ALWAYS__"; }
+const github = ${JSON.stringify(githubCtx)};
+const runner = ${JSON.stringify(runnerCtx)};
+const steps = ${JSON.stringify(stepsCtx)};
+const inputs = ${JSON.stringify(inputsCtx)};
+const result = (${transformed});
+console.log(result)
+`;
+    Trace("evaluateUsingJavaScript(%s): %s", codeBlock, jsCode);
+
+    const jsPath = Deno.makeTempFileSync({ dir: this.ctx.tempDir || undefined, suffix: ".js" });
+    try {
+      Deno.writeTextFileSync(jsPath, jsCode);
+      const cmd = new Deno.Command(this.denoPath, {
+        args: denoRunArgs("--no-prompt", jsPath),
+        cwd: this.ctx.workspace || undefined,
+        stdin: "null",
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const { code, stdout, stderr } = cmd.outputSync();
+      if (code !== 0) {
+        throw new Error(`deno evaluation failed: ${new TextDecoder().decode(stderr)}`);
+      }
+      return new TextDecoder().decode(stdout).trim();
+    } finally {
+      try {
+        Deno.removeSync(jsPath);
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  /** Build the github context for expression evaluation. */
+  buildGitHubContext(): Record<string, unknown> {
+    const ctx: Record<string, unknown> = {};
+    const envMappings: Record<string, string> = {
+      actor: "GITHUB_ACTOR",
+      actor_id: "GITHUB_ACTOR_ID",
+      repository: "GITHUB_REPOSITORY",
+      api: "GITHUB_API",
+      token: "GITHUB_TOKEN",
+    };
+    for (const [key, envVar] of Object.entries(envMappings)) {
+      if (this.ctx.env[envVar] !== undefined) ctx[key] = this.ctx.env[envVar];
+    }
+    ctx["event"] = { inputs: this.ctx.inputs };
+    return ctx;
+  }
+
+  /** Execute a step that uses an action. */
+  private async executeStepUses(
+    step: PolicyEngineWorkflowJobStep,
+    env: Record<string, string>,
+  ): Promise<void> {
+    const uses = step.uses!;
+    let actionPath = "";
+
+    if (uses.startsWith("./") || uses.startsWith("/")) {
+      actionPath = uses.startsWith("/") ? uses : join(this.ctx.workspace, uses);
+      if (!(await exists(actionPath))) {
+        throw new Error(`local action path does not exist: ${actionPath}`);
+      }
+      Debug("action resolved from local path: %s", actionPath);
+    } else if (uses.includes("@")) {
+      const [orgRepo, version] = splitN(uses, "@", 2);
+
+      let repoActionsDir = env["ACTIONS_DIR"];
+      if (!repoActionsDir) repoActionsDir = join(this.ctx.workspace, ".tangled", "actions");
+      const repoLocal = join(repoActionsDir, orgRepo);
+      if (await exists(repoLocal)) {
+        actionPath = repoLocal;
+        Debug("action %s resolved from repo-supplied dir: %s", orgRepo, actionPath);
+      }
+
+      if (!actionPath) {
+        const bundledDir = Deno.env.get("BUNDLED_ACTIONS_DIR");
+        if (bundledDir) {
+          const bundledPath = join(bundledDir, orgRepo);
+          if (await exists(bundledPath)) {
+            actionPath = bundledPath;
+            Debug("action %s resolved from bundled dir: %s", orgRepo, actionPath);
+          }
+        }
+      }
+
+      if (!actionPath) {
+        Debug("downloading action %s@%s from GitHub", orgRepo, version);
+        actionPath = await this.downloadAction(orgRepo, version);
+        Debug("action %s downloaded to: %s", orgRepo, actionPath);
+      }
+    } else {
+      throw new Error(
+        `unsupported uses format (expected org/repo@version or ./path): ${uses}`,
+      );
+    }
+
+    let actionYamlPath = join(actionPath, "action.yml");
+    if (!(await exists(actionYamlPath))) actionYamlPath = join(actionPath, "action.yaml");
+    const actionDef = parseYaml(await Deno.readTextFile(actionYamlPath)) as ActionDef;
+
+    // Add default inputs.
+    for (const [inputName, inputDef] of Object.entries(actionDef.inputs ?? {})) {
+      const envKey = "INPUT_" + inputName.toUpperCase();
+      if (env[envKey] === undefined && inputDef.default) {
+        env[envKey] = this.evaluateExpression(inputDef.default);
+      }
+    }
+
+    env["GITHUB_ACTION_PATH"] = actionPath;
+
+    const using = actionDef.runs?.using ?? "";
+    Debug("executing action type: %s", using);
+    if (using.startsWith("node")) {
+      await this.executeNodeAction(actionPath, actionDef.runs?.main ?? "", env, step.id);
+    } else if (using === "composite") {
+      await this.executeCompositeAction(actionDef.runs?.steps ?? [], env);
+    } else {
+      throw new Error(`unsupported action type: ${using}`);
+    }
+  }
+
+  /** Download a GitHub Action to the cache directory and return its path. */
+  private async downloadAction(orgRepo: string, version: string): Promise<string> {
+    const extractedPath = join(this.ctx.cacheDir, orgRepo, "extracted");
+    if (await exists(extractedPath)) return extractedPath;
+
+    const downloadDir = join(this.ctx.cacheDir, orgRepo);
+    await Deno.mkdir(downloadDir, { recursive: true });
+
+    const urls = [
+      `https://github.com/${orgRepo}/archive/refs/tags/${version}.zip`,
+      `https://github.com/${orgRepo}/archive/${version}.zip`,
+      `https://github.com/${orgRepo}/archive/refs/heads/${version}.zip`,
+    ];
+
+    let downloadErr: Error | null = null;
+    for (const downloadURL of urls) {
+      const compressedPath = join(downloadDir, "compressed.zip");
+      try {
+        const headers: HeadersInit = {};
+        const token = this.ctx.secrets["GITHUB_TOKEN"];
+        if (token) headers["Authorization"] = "Bearer " + token;
+
+        const resp = await fetch(downloadURL, { headers });
+        if (!resp.ok) {
+          downloadErr = new Error(`download failed with status: ${resp.status}`);
+          continue;
+        }
+        await Deno.writeFile(compressedPath, new Uint8Array(await resp.arrayBuffer()));
+
+        const extractedTmpPath = join(downloadDir, "extracted_tmp");
+        await unzip(compressedPath, extractedTmpPath);
+
+        const entries: Deno.DirEntry[] = [];
+        for await (const e of Deno.readDir(extractedTmpPath)) entries.push(e);
+        if (entries.length === 0) {
+          downloadErr = new Error("failed to find extracted directory");
+          continue;
+        }
+
+        const srcDir = join(extractedTmpPath, entries[0].name);
+        await Deno.rename(srcDir, extractedPath);
+        await this.removeAll(extractedTmpPath);
+        try {
+          await Deno.remove(compressedPath);
+        } catch { /* ignore */ }
+        return extractedPath;
+      } catch (e) {
+        downloadErr = e as Error;
+      }
+    }
+    throw new Error(`failed to download action from any URL: ${downloadErr?.message}`);
+  }
+
+  /** Execute a Node.js action using Deno's Node compatibility layer. */
+  private async executeNodeAction(
+    actionPath: string,
+    main: string,
+    env: Record<string, string>,
+    stepID: string | undefined,
+  ): Promise<void> {
+    const ghFiles: Array<[string, string]> = [
+      ["GITHUB_OUTPUT", "node-output-"],
+      ["GITHUB_ENV", "node-env-"],
+      ["GITHUB_PATH", "node-path-"],
+      ["GITHUB_STATE", "node-state-"],
+    ];
+    const cleanup: string[] = [];
+    for (const [envKey, prefix] of ghFiles) {
+      const f = await Deno.makeTempFile({ dir: this.ctx.tempDir, prefix, suffix: ".txt" });
+      env[envKey] = f;
+      cleanup.push(f);
+    }
+
+    try {
+      // Many actions are ncc-bundled CommonJS. Deno defaults a type-less
+      // package.json to ESM, leaving __dirname undefined — force commonjs.
+      const actionPkgPath = join(actionPath, "package.json");
+      try {
+        const pkg = JSON.parse(await Deno.readTextFile(actionPkgPath));
+        if (pkg.type === undefined) {
+          pkg.type = "commonjs";
+          await Deno.writeTextFile(actionPkgPath, JSON.stringify(pkg));
+        }
+      } catch {
+        await Deno.writeTextFile(actionPkgPath, `{"type":"commonjs"}`);
+      }
+
+      const mainPath = join(actionPath, main);
+      const cmd = new Deno.Command(this.denoPath, {
+        args: denoRunArgs("--allow-all", "--no-prompt", mainPath),
+        cwd: this.ctx.workspace,
+        env: env,
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const output = await this.runAndStreamOutput(cmd);
+      this.ctx.consoleOutput.push(output);
+
+      // Parse outputs from GITHUB_OUTPUT.
+      if (stepID) {
+        const content = await readTextOrEmpty(env["GITHUB_OUTPUT"]);
+        if (content) {
+          const outputs = parseGitHubActionsOutputs(content);
+          if (!this.ctx.outputs[stepID]) this.ctx.outputs[stepID] = {};
+          this.ctx.outputs[stepID]["outputs"] = outputs;
+        }
+      }
+
+      // Apply env updates from GITHUB_ENV.
+      const envContent = await readTextOrEmpty(env["GITHUB_ENV"]);
+      if (envContent) {
+        for (const [k, v] of Object.entries(parseGitHubActionsOutputs(envContent))) {
+          this.ctx.env[k] = v;
+        }
+      }
+    } finally {
+      for (const f of cleanup) {
+        try {
+          await Deno.remove(f);
+        } catch { /* ignore */ }
+      }
+    }
+  }
+
+  /** Execute a composite action's run steps. */
+  private async executeCompositeAction(
+    steps: ActionStep[],
+    env: Record<string, string>,
+  ): Promise<void> {
+    for (const step of steps) {
+      if (!step.run) continue;
+      const shell = step.shell || this.ctx.shell;
+      const stepEnv = { ...env };
+      for (const [k, v] of Object.entries(step.env ?? {})) {
+        stepEnv[k] = this.evaluateExpression(v);
+      }
+      await this.runShellCommand(step.run, shell, stepEnv);
+    }
+  }
+
+  /** Execute a `run` step. */
+  private async executeStepRun(
+    step: PolicyEngineWorkflowJobStep,
+    env: Record<string, string>,
+  ): Promise<void> {
+    const runScript = this.evaluateExpression(step.run!);
+
+    const outputFile = await Deno.makeTempFile({ dir: this.ctx.tempDir, prefix: "output-", suffix: ".txt" });
+    const envFile = await Deno.makeTempFile({ dir: this.ctx.tempDir, prefix: "env-", suffix: ".txt" });
+    const pathFile = await Deno.makeTempFile({ dir: this.ctx.tempDir, prefix: "path-", suffix: ".txt" });
+
+    env["GITHUB_OUTPUT"] = outputFile;
+    env["GITHUB_ENV"] = envFile;
+    env["GITHUB_PATH"] = pathFile;
+
+    const shell = step.shell || this.ctx.shell;
+
+    try {
+      await this.runShellCommand(runScript, shell, env);
+
+      if (step.id) {
+        const outputs = parseGitHubActionsOutputs(await readTextOrEmpty(outputFile));
+        if (!this.ctx.outputs[step.id]) this.ctx.outputs[step.id] = {};
+        this.ctx.outputs[step.id]["outputs"] = outputs;
+      }
+
+      for (const [k, v] of Object.entries(parseGitHubActionsOutputs(await readTextOrEmpty(envFile)))) {
+        this.ctx.env[k] = v;
+      }
+    } finally {
+      for (const f of [outputFile, envFile, pathFile]) {
+        try {
+          await Deno.remove(f);
+        } catch { /* ignore */ }
+      }
+    }
+  }
+
+  /** Run a shell command, writing the script to a temp file. */
+  private async runShellCommand(
+    script: string,
+    shell: string,
+    env: Record<string, string>,
+  ): Promise<void> {
+    Debug("running shell command: shell=%s", shell);
+    Trace("script content:\n%s", script);
+
+    const scriptPath = await Deno.makeTempFile({ dir: this.ctx.tempDir, prefix: "script-" });
+    try {
+      await Deno.writeTextFile(scriptPath, script);
+
+      let shellParts = shell.trim().split(/\s+/).filter((p) => p.length > 0);
+      if (shellParts.length === 0) shellParts = ["bash", "-xe"];
+
+      // Replace {0} placeholder with the script path.
+      const args: string[] = [];
+      let found = false;
+      for (const part of shellParts) {
+        if (part.includes("{0}")) {
+          args.push(part.replace("{0}", scriptPath));
+          found = true;
+        } else {
+          args.push(part);
+        }
+      }
+      if (!found) args.push(scriptPath);
+
+      const cmd = new Deno.Command(args[0], {
+        args: args.slice(1),
+        cwd: this.ctx.workspace,
+        env: env,
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const output = await this.runAndStreamOutput(cmd);
+      this.ctx.consoleOutput.push(output);
+      this.parseAnnotations(output);
+    } finally {
+      try {
+        await Deno.remove(scriptPath);
+      } catch { /* ignore */ }
+    }
+  }
+
+  /** Run a command, capturing merged stdout/stderr and streaming lines to the task. */
+  private async runAndStreamOutput(cmd: Deno.Command): Promise<string> {
+    const child = cmd.spawn();
+    const decoder = new TextDecoder();
+    let output = "";
+
+    const pump = async (stream: ReadableStream<Uint8Array>) => {
+      for await (const chunk of stream) {
+        const text = decoder.decode(chunk, { stream: true });
+        output += text;
+        for (const line of text.split("\n")) {
+          if (line !== "") {
+            Trace("| %s", line);
+            if (this.task) this.task.appendConsoleOutput(line);
+          }
+        }
+      }
+    };
+
+    await Promise.all([pump(child.stdout), pump(child.stderr)]);
+    const status = await child.status;
+    if (!status.success) {
+      throw new Error(`command exited with code ${status.code}`);
+    }
+    return output;
+  }
+
+  /** Parse GitHub Actions workflow command annotations from output. */
+  private parseAnnotations(output: string): void {
+    for (let line of output.split("\n")) {
+      if (!line.startsWith("::")) continue;
+      line = line.slice(2);
+      const idx = line.indexOf("::");
+      const levelAndParams = idx >= 0 ? line.slice(0, idx) : line;
+      const message = idx >= 0 ? line.slice(idx + 2) : "";
+
+      const spaceIdx = levelAndParams.indexOf(" ");
+      const level = spaceIdx >= 0 ? levelAndParams.slice(0, spaceIdx) : levelAndParams;
+      if (level !== "error" && level !== "warning" && level !== "notice") continue;
+
+      const annotation: GitHubCheckSuiteAnnotation = {
+        annotation_level: level,
+        message,
+        title: message,
+        raw_details: "::" + line,
+      };
+
+      if (spaceIdx >= 0) {
+        const params = new URLSearchParams(levelAndParams.slice(spaceIdx + 1).replace(/,/g, "&"));
+        const file = params.get("file");
+        if (file) annotation.path = file;
+        const path = params.get("path");
+        if (path) annotation.path = path;
+        const title = params.get("title");
+        if (title) annotation.title = title;
+        const lineNum = params.get("line");
+        if (lineNum && !isNaN(Number(lineNum))) {
+          annotation.start_line = Number(lineNum);
+          annotation.end_line = Number(lineNum);
+        }
+        const endLine = params.get("endLine");
+        if (endLine && !isNaN(Number(endLine))) annotation.end_line = Number(endLine);
+      }
+
+      (this.ctx.annotations[level] ??= []).push(annotation);
+    }
+  }
+
+  private createSuccessStatus(): PolicyEngineStatus {
+    return {
+      status: StatusComplete,
+      detail: {
+        id: "",
+        exit_status: "success",
+        outputs: {},
+        annotations: { ...this.ctx.annotations },
+      },
+      console_output: this.ctx.consoleOutput.join("\n"),
+    };
+  }
+
+  private createErrorStatus(err: Error): PolicyEngineStatus {
+    const annotations: Record<string, unknown> = { ...this.ctx.annotations };
+    annotations["error"] = [err.message];
+    return {
+      status: StatusComplete,
+      detail: {
+        id: "",
+        exit_status: "failure",
+        outputs: {},
+        annotations,
+      },
+      console_output: this.ctx.consoleOutput.join("\n"),
+    };
+  }
+}
+
+// --- module-level helpers ---
+
+/**
+ * Recursively convert string "true"/"false" into real booleans so that
+ * comparisons like `steps.x.outputs.y === true` behave as expected.
+ */
+export function convertBoolStrings(value: unknown): unknown {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (Array.isArray(value)) return value.map(convertBoolStrings);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = convertBoolStrings(v);
+    return out;
+  }
+  return value;
+}
+
+/** Convert dot notation to bracket notation, skipping string literals. */
+export function transformPropertyAccessors(jsCode: string): string {
+  let result = "";
+  let i = 0;
+  while (i < jsCode.length) {
+    const ch = jsCode[i];
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      result += ch;
+      i++;
+      while (i < jsCode.length) {
+        result += jsCode[i];
+        if (jsCode[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+    } else if (ch === ".") {
+      result += "['";
+      i++;
+      const start = i;
+      while (i < jsCode.length && /[A-Za-z0-9_\-]/.test(jsCode[i])) i++;
+      result += jsCode.slice(start, i);
+      result += "']";
+    } else {
+      result += ch;
+      i++;
+    }
+  }
+  return result;
+}
+
+/** Resolve a property path like "github.actor" from data. */
+export function resolvePropertyPath(path: string, data: Record<string, unknown>): unknown {
+  let current: unknown = data;
+  for (const part of path.split(".")) {
+    if (current && typeof current === "object" && !Array.isArray(current)) {
+      current = (current as Record<string, unknown>)[part];
+      if (current === undefined) return undefined;
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+/** Parse GitHub Actions output format (key=value and key<<delimiter blocks). */
+export function parseGitHubActionsOutputs(content: string): Record<string, string> {
+  const outputs: Record<string, string> = {};
+  let currentKey = "";
+  let currentDelimiter = "";
+  let currentValue = "";
+
+  for (const line of content.split("\n")) {
+    if (currentDelimiter !== "") {
+      if (line.startsWith(currentDelimiter)) {
+        outputs[currentKey] = currentValue.replace(/\n$/, "");
+        currentKey = "";
+        currentDelimiter = "";
+        currentValue = "";
+      } else {
+        currentValue += line + "\n";
+      }
+    } else if (line.includes("<<") && currentKey === "") {
+      const [k, d] = splitN(line, "<<", 2);
+      currentKey = k.trim();
+      currentDelimiter = d.trim();
+    } else if (line.includes("=") && currentKey === "") {
+      const [k, v] = splitN(line, "=", 2);
+      outputs[k.trim()] = v ?? "";
+    }
+  }
+  return outputs;
+}
+
+/** Build the argument list for a `deno run` invocation, quieting downloads. */
+export function denoRunArgs(...args: string[]): string[] {
+  const result = ["run"];
+  if (Deno.env.get("DEBUG_DENO_PACKAGES") !== "1") result.push("--quiet");
+  return [...result, ...args];
+}
+
+/** Split a string on `sep` into at most `n` parts (like Go's strings.SplitN). */
+function splitN(s: string, sep: string, n: number): string[] {
+  const parts = s.split(sep);
+  if (parts.length <= n) return parts;
+  return [...parts.slice(0, n - 1), parts.slice(n - 1).join(sep)];
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readTextOrEmpty(path: string | undefined): Promise<string> {
+  if (!path) return "";
+  try {
+    return await Deno.readTextFile(path);
+  } catch {
+    return "";
+  }
+}
+
+async function unzip(src: string, dest: string): Promise<void> {
+  const cmd = new Deno.Command("unzip", { args: ["-q", "-o", src, "-d", dest] });
+  const { success, code } = await cmd.output();
+  if (!success) throw new Error(`unzip failed with code ${code}`);
+}

--- a/src/policy_engine/ts/src/workflow.ts
+++ b/src/policy_engine/ts/src/workflow.ts
@@ -17,6 +17,8 @@ import {
   WorkflowExecutionContext,
 } from "./models.ts";
 import { Debug, Info, LogError, Trace } from "./logger.ts";
+import { ExpressionEvaluator } from "./eval.ts";
+import { resolveSandboxConfig, type SandboxConfig } from "./config.ts";
 
 /** Parse a workflow from a string (YAML) or an object. */
 export function parseWorkflow(input: unknown): PolicyEngineWorkflow {
@@ -46,13 +48,22 @@ interface ActionDef {
 
 /** Executes workflows. */
 export class WorkflowExecutor {
-  denoPath: string;
   ctx: WorkflowExecutionContext;
   task: Task | null = null;
+  readonly sandbox: SandboxConfig;
+  private evaluator: ExpressionEvaluator;
+  // Path to the deno binary, used only to run node-based `uses` actions (the
+  // action's own code) — never for evaluating ${{ }} expressions, which run
+  // in-process in the sandboxed worker. In net-only mode no action runs at all.
+  private denoPath: string;
 
-  constructor(denoPath = Deno.execPath()) {
-    this.denoPath = denoPath;
+  constructor(opts: { sandbox?: SandboxConfig; denoPath?: string } = {}) {
     this.ctx = new WorkflowExecutionContext();
+    this.sandbox = opts.sandbox ?? resolveSandboxConfig();
+    this.denoPath = opts.denoPath ?? Deno.execPath();
+    // The expression sandbox is granted network access only in net-only mode;
+    // it never receives filesystem or subprocess permissions.
+    this.evaluator = new ExpressionEvaluator({ allowNet: this.sandbox.netOnly });
   }
 
   /** Execute a parsed workflow and return its final status. */
@@ -84,6 +95,7 @@ export class WorkflowExecutor {
       await this.removeAll(this.ctx.workspace);
       await this.removeAll(this.ctx.toolCacheDir);
       await this.removeAll(this.ctx.homeDir);
+      this.evaluator.close();
     }
   }
 
@@ -122,6 +134,14 @@ export class WorkflowExecutor {
       this.ctx.env["GITHUB_TOKEN"] = token;
     }
 
+    // In net-only mode the engine must never touch the filesystem, so the
+    // ephemeral workspace/cache/home directories are not created. Any step
+    // that would need them is refused later (see assertExecAllowed).
+    if (this.sandbox.netOnly) {
+      Info("net-only sandbox: filesystem and subprocess execution are disabled");
+      return;
+    }
+
     const cwd = Deno.cwd();
     this.ctx.cacheDir = join(cwd, ".cache");
     this.ctx.tempDir = join(cwd, ".tempdir");
@@ -131,6 +151,18 @@ export class WorkflowExecutor {
     this.ctx.workspace = await Deno.makeTempDir({ dir: this.ctx.tempDir, prefix: "workspace-" });
     this.ctx.toolCacheDir = await Deno.makeTempDir({ dir: this.ctx.tempDir, prefix: "toolcache-" });
     this.ctx.homeDir = await Deno.makeTempDir({ dir: this.ctx.tempDir, prefix: "home-" });
+  }
+
+  /**
+   * Refuse operations that require the filesystem or subprocess execution when
+   * running in the net-only sandbox.
+   */
+  private assertExecAllowed(what: string): void {
+    if (this.sandbox.netOnly) {
+      throw new Error(
+        `${what} requires filesystem/exec access, which is disabled in net-only sandbox mode`,
+      );
+    }
   }
 
   /** Execute a single job. */
@@ -143,7 +175,7 @@ export class WorkflowExecutor {
       else if (step.name) stepName = step.name;
 
       if (step.if !== undefined && step.if !== null) {
-        if (!this.evaluateCondition(step.if)) {
+        if (!(await this.evaluateCondition(step.if))) {
           Info("step %s skipped (if condition false)", stepName);
           continue;
         }
@@ -152,7 +184,7 @@ export class WorkflowExecutor {
       Info("starting step: %s", stepName);
       if (step.shell) this.ctx.shell = step.shell;
 
-      const stepEnv = this.buildStepEnv(step);
+      const stepEnv = await this.buildStepEnv(step);
 
       this.emit(`##[group]${stepName}`);
 
@@ -189,7 +221,7 @@ export class WorkflowExecutor {
    * conditions without ${{ }} are wrapped before evaluation. Unresolved
    * expressions fail closed (return false via throw), matching GitHub Actions.
    */
-  evaluateCondition(condition: unknown): boolean {
+  async evaluateCondition(condition: unknown): Promise<boolean> {
     if (typeof condition === "boolean") return condition;
     if (typeof condition === "number") return condition !== 0;
     if (typeof condition === "string") {
@@ -200,7 +232,7 @@ export class WorkflowExecutor {
 
       let exprStr = condition;
       if (!exprStr.includes("${{")) exprStr = "${{ " + exprStr + " }}";
-      let evaluated = this.evaluateExpression(exprStr);
+      let evaluated = await this.evaluateExpression(exprStr);
       if (evaluated.includes("${{")) {
         throw new Error(`could not evaluate expression ${JSON.stringify(condition)}`);
       }
@@ -218,17 +250,17 @@ export class WorkflowExecutor {
   }
 
   /** Build the environment map for a step. */
-  buildStepEnv(step: PolicyEngineWorkflowJobStep): Record<string, string> {
+  async buildStepEnv(step: PolicyEngineWorkflowJobStep): Promise<Record<string, string>> {
     const env: Record<string, string> = {};
 
     for (const [k, v] of Object.entries(this.ctx.env)) {
       env[k] = String(v);
     }
     for (const [k, v] of Object.entries(step.env ?? {})) {
-      env[k] = this.evaluateExpression(String(v));
+      env[k] = await this.evaluateExpression(String(v));
     }
     for (const [k, v] of Object.entries(step.with ?? {})) {
-      env["INPUT_" + k.toUpperCase()] = this.evaluateExpression(String(v));
+      env["INPUT_" + k.toUpperCase()] = await this.evaluateExpression(String(v));
     }
 
     env["GITHUB_WORKSPACE"] = this.ctx.workspace;
@@ -241,17 +273,28 @@ export class WorkflowExecutor {
   }
 
   /** Evaluate all ${{ ... }} occurrences in a string. */
-  evaluateExpression(expr: string): string {
+  async evaluateExpression(expr: string): Promise<string> {
     if (!expr.includes("${{")) return expr;
-    return expr.replace(/\$\{\{\s*([\s\S]+?)\s*\}\}/g, (_m, inner: string) => {
-      return this.evaluateInnerExpression(inner.trim());
-    });
+    const re = /\$\{\{\s*([\s\S]+?)\s*\}\}/g;
+    let result = "";
+    let last = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(expr)) !== null) {
+      result += expr.slice(last, m.index);
+      result += await this.evaluateInnerExpression(m[1].trim());
+      last = m.index + m[0].length;
+    }
+    result += expr.slice(last);
+    return result;
   }
 
-  /** Evaluate a single expression (content between ${{ and }}) using Deno. */
-  private evaluateInnerExpression(inner: string): string {
+  /**
+   * Evaluate a single expression (content between ${{ and }}) natively in the
+   * sandboxed worker. Falls back to simple property-path resolution on error.
+   */
+  private async evaluateInnerExpression(inner: string): Promise<string> {
     try {
-      return this.evaluateUsingJavaScript(inner);
+      return await this.evaluateUsingJavaScript(inner);
     } catch {
       // Fall back to simple property-path resolution.
       const data: Record<string, unknown> = {
@@ -267,10 +310,11 @@ export class WorkflowExecutor {
   }
 
   /**
-   * Evaluate an expression by constructing a JS file with the github, runner,
-   * steps, and inputs contexts and running it with Deno.
+   * Evaluate an expression as JavaScript inside the permission-restricted
+   * worker. The github, runner, steps, and inputs contexts are embedded in a
+   * self-contained IIFE — no subprocess is spawned and no file is written.
    */
-  private evaluateUsingJavaScript(codeBlock: string): string {
+  private async evaluateUsingJavaScript(codeBlock: string): Promise<string> {
     const githubCtx = this.buildGitHubContext();
     const stepsCtx = convertBoolStrings(this.ctx.outputs);
     const inputsCtx = this.ctx.inputs;
@@ -278,38 +322,17 @@ export class WorkflowExecutor {
 
     const transformed = transformPropertyAccessors(codeBlock);
 
-    const jsCode = `function always() { return "__GITHUB_ACTIONS_ALWAYS__"; }
+    const jsCode = `(() => {
+function always() { return "__GITHUB_ACTIONS_ALWAYS__"; }
 const github = ${JSON.stringify(githubCtx)};
 const runner = ${JSON.stringify(runnerCtx)};
 const steps = ${JSON.stringify(stepsCtx)};
 const inputs = ${JSON.stringify(inputsCtx)};
-const result = (${transformed});
-console.log(result)
-`;
+return (${transformed});
+})()`;
     Trace("evaluateUsingJavaScript(%s): %s", codeBlock, jsCode);
 
-    const jsPath = Deno.makeTempFileSync({ dir: this.ctx.tempDir || undefined, suffix: ".js" });
-    try {
-      Deno.writeTextFileSync(jsPath, jsCode);
-      const cmd = new Deno.Command(this.denoPath, {
-        args: denoRunArgs("--no-prompt", jsPath),
-        cwd: this.ctx.workspace || undefined,
-        stdin: "null",
-        stdout: "piped",
-        stderr: "piped",
-      });
-      const { code, stdout, stderr } = cmd.outputSync();
-      if (code !== 0) {
-        throw new Error(`deno evaluation failed: ${new TextDecoder().decode(stderr)}`);
-      }
-      return new TextDecoder().decode(stdout).trim();
-    } finally {
-      try {
-        Deno.removeSync(jsPath);
-      } catch {
-        // ignore
-      }
-    }
+    return await this.evaluator.evaluate(jsCode);
   }
 
   /** Build the github context for expression evaluation. */
@@ -334,6 +357,7 @@ console.log(result)
     step: PolicyEngineWorkflowJobStep,
     env: Record<string, string>,
   ): Promise<void> {
+    this.assertExecAllowed(`action "${step.uses}"`);
     const uses = step.uses!;
     let actionPath = "";
 
@@ -384,7 +408,7 @@ console.log(result)
     for (const [inputName, inputDef] of Object.entries(actionDef.inputs ?? {})) {
       const envKey = "INPUT_" + inputName.toUpperCase();
       if (env[envKey] === undefined && inputDef.default) {
-        env[envKey] = this.evaluateExpression(inputDef.default);
+        env[envKey] = await this.evaluateExpression(inputDef.default);
       }
     }
 
@@ -535,7 +559,7 @@ console.log(result)
       const shell = step.shell || this.ctx.shell;
       const stepEnv = { ...env };
       for (const [k, v] of Object.entries(step.env ?? {})) {
-        stepEnv[k] = this.evaluateExpression(v);
+        stepEnv[k] = await this.evaluateExpression(v);
       }
       await this.runShellCommand(step.run, shell, stepEnv);
     }
@@ -546,7 +570,8 @@ console.log(result)
     step: PolicyEngineWorkflowJobStep,
     env: Record<string, string>,
   ): Promise<void> {
-    const runScript = this.evaluateExpression(step.run!);
+    this.assertExecAllowed("run step");
+    const runScript = await this.evaluateExpression(step.run!);
 
     const outputFile = await Deno.makeTempFile({
       dir: this.ctx.tempDir,

--- a/src/policy_engine/ts/src/workflow.ts
+++ b/src/policy_engine/ts/src/workflow.ts
@@ -18,6 +18,7 @@ import {
 } from "./models.ts";
 import { Debug, Info, LogError, Trace } from "./logger.ts";
 import { ExpressionEvaluator } from "./eval.ts";
+import { runActionInWorker } from "./action_worker.ts";
 import { resolveSandboxConfig, type SandboxConfig } from "./config.ts";
 
 /** Parse a workflow from a string (YAML) or an object. */
@@ -357,7 +358,6 @@ return (${transformed});
     step: PolicyEngineWorkflowJobStep,
     env: Record<string, string>,
   ): Promise<void> {
-    this.assertExecAllowed(`action "${step.uses}"`);
     const uses = step.uses!;
     let actionPath = "";
 
@@ -390,6 +390,15 @@ return (${transformed});
       }
 
       if (!actionPath) {
+        // Downloading requires writing to the cache directory; not available
+        // in the net-only sandbox. Actions must be supplied via a local path,
+        // ACTIONS_DIR, or BUNDLED_ACTIONS_DIR.
+        if (this.sandbox.netOnly) {
+          throw new Error(
+            `cannot download action ${orgRepo}@${version} in net-only mode; ` +
+              `provide it via a local path, ACTIONS_DIR, or BUNDLED_ACTIONS_DIR`,
+          );
+        }
         Debug("downloading action %s@%s from GitHub", orgRepo, version);
         actionPath = await this.downloadAction(orgRepo, version);
         Debug("action %s downloaded to: %s", orgRepo, actionPath);
@@ -417,11 +426,65 @@ return (${transformed});
     const using = actionDef.runs?.using ?? "";
     Debug("executing action type: %s", using);
     if (using.startsWith("node")) {
-      await this.executeNodeAction(actionPath, actionDef.runs?.main ?? "", env, step.id);
+      // In net-only mode the action runs in the permission-restricted worker;
+      // otherwise it runs as a full Deno subprocess (which also supports
+      // CommonJS/ncc bundles).
+      if (this.sandbox.netOnly) {
+        await this.executeNodeActionSandboxed(actionPath, actionDef.runs?.main ?? "", env, step.id);
+      } else {
+        await this.executeNodeActionSubprocess(
+          actionPath,
+          actionDef.runs?.main ?? "",
+          env,
+          step.id,
+        );
+      }
     } else if (using === "composite") {
+      // Composite actions execute shell steps, which require process execution.
+      this.assertExecAllowed("composite action");
       await this.executeCompositeAction(actionDef.runs?.steps ?? [], env);
     } else {
       throw new Error(`unsupported action type: ${using}`);
+    }
+  }
+
+  /**
+   * Run a JS/TS action's source in the sandboxed worker (net-only). The action
+   * gets network access (if enabled) but no filesystem or subprocess access;
+   * GITHUB_OUTPUT/GITHUB_ENV writes are captured via an in-memory virtual FS.
+   */
+  private async executeNodeActionSandboxed(
+    actionPath: string,
+    main: string,
+    env: Record<string, string>,
+    stepID: string | undefined,
+  ): Promise<void> {
+    const source = await Deno.readTextFile(join(actionPath, main));
+    const result = await runActionInWorker({
+      source,
+      env,
+      allowNet: this.sandbox.netOnly, // net granted in net-only mode
+      onLine: (line) => {
+        Trace("| %s", line);
+        this.ctx.consoleOutput.push(line);
+        if (this.task) this.task.appendConsoleOutput(line);
+        this.parseAnnotations(line);
+      },
+    });
+
+    if (stepID && result.output) {
+      const outputs = parseGitHubActionsOutputs(result.output);
+      if (!this.ctx.outputs[stepID]) this.ctx.outputs[stepID] = {};
+      this.ctx.outputs[stepID]["outputs"] = outputs;
+    }
+    if (result.env) {
+      for (const [k, v] of Object.entries(parseGitHubActionsOutputs(result.env))) {
+        this.ctx.env[k] = v;
+      }
+    }
+
+    if (result.code !== 0) {
+      throw new Error(`action exited with code ${result.code}`);
     }
   }
 
@@ -478,8 +541,11 @@ return (${transformed});
     throw new Error(`failed to download action from any URL: ${downloadErr?.message}`);
   }
 
-  /** Execute a Node.js action using Deno's Node compatibility layer. */
-  private async executeNodeAction(
+  /**
+   * Execute a Node.js action as a full Deno subprocess (Node compatibility
+   * layer). Used in the default sandbox; supports CommonJS/ncc bundles.
+   */
+  private async executeNodeActionSubprocess(
     actionPath: string,
     main: string,
     env: Record<string, string>,

--- a/src/policy_engine/ts/src/workflow_test.ts
+++ b/src/policy_engine/ts/src/workflow_test.ts
@@ -1,0 +1,45 @@
+import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import {
+  convertBoolStrings,
+  parseGitHubActionsOutputs,
+  resolvePropertyPath,
+  transformPropertyAccessors,
+} from "./workflow.ts";
+
+Deno.test("parseGitHubActionsOutputs: key=value", () => {
+  const out = parseGitHubActionsOutputs("foo=bar\nbaz=qux\n");
+  assertEquals(out, { foo: "bar", baz: "qux" });
+});
+
+Deno.test("parseGitHubActionsOutputs: heredoc block", () => {
+  const content = "msg<<EOF\nline one\nline two\nEOF\nflag=true\n";
+  const out = parseGitHubActionsOutputs(content);
+  assertEquals(out, { msg: "line one\nline two", flag: "true" });
+});
+
+Deno.test("convertBoolStrings: nested string booleans become real booleans", () => {
+  const input = { a: { outputs: { flag: "true", other: "false", name: "x" } } };
+  assertEquals(convertBoolStrings(input), {
+    a: { outputs: { flag: true, other: false, name: "x" } },
+  });
+});
+
+Deno.test("transformPropertyAccessors: dots become bracket access", () => {
+  assertEquals(
+    transformPropertyAccessors("steps.greet.outputs.flag === true"),
+    "steps['greet']['outputs']['flag'] === true",
+  );
+});
+
+Deno.test("transformPropertyAccessors: leaves string literals untouched", () => {
+  assertEquals(
+    transformPropertyAccessors(`github.actor === "a.b.c"`),
+    `github['actor'] === "a.b.c"`,
+  );
+});
+
+Deno.test("resolvePropertyPath: resolves nested values", () => {
+  const data = { github: { actor: "octocat" } };
+  assertEquals(resolvePropertyPath("github.actor", data), "octocat");
+  assertEquals(resolvePropertyPath("github.missing", data), undefined);
+});

--- a/src/policy_engine/ts/src/workflow_test.ts
+++ b/src/policy_engine/ts/src/workflow_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { assertEquals } from "@std/assert";
 import {
   convertBoolStrings,
   parseGitHubActionsOutputs,


### PR DESCRIPTION
Adds a TypeScript implementation of the policy engine (GitHub Actions workflow evaluation) built on **Deno + Hono**, ported from the Go implementation in `src/policy_engine/common`. Lives under `src/policy_engine/ts/`.

## What's included
- **Models / task manager** (`src/models.ts`) — request/response types, `Task` with subscriber broadcast, `TaskManager`, execution context
- **Workflow executor** (`src/workflow.ts`) — `${{ }}` expression eval via sandboxed `deno run`, `run` steps, `uses` (node/composite/local/remote w/ GitHub download+cache), GITHUB_OUTPUT/ENV parsing (incl. heredoc), boolean coercion, `::error/warning/notice` annotation parsing, ephemeral workspace/HOME/tool-cache
- **Hono server** (`src/server.ts`) — `/request/create`, `/request/status/:id`, `/request/console_output/:id`, SSE stream, `/webhook/github`, `/rate_limit`, `/health`, CORS + request logging
- **CLI** (`main.ts`) — `api` (TCP or unix socket) and `run` commands
- **Logger** (`src/logger.ts`), **unit tests** (`src/workflow_test.ts`), and a README

## Verification
- `deno check main.ts` — clean
- `deno test` — 6/6 pass
- End-to-end smoke tested both the `run` CLI and the HTTP API (create → status → console_output); expression eval, conditional skip, output parsing, and annotations confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)